### PR TITLE
Add support for custom projection bbox

### DIFF
--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -525,7 +525,9 @@ def tms_to_geotiff(
             for k, (fut, corner_xy) in enumerate(zip(futures, corners), 1):
                 bigim = paste_tile(bigim, base_size, fut.result(), corner_xy, bbox)
                 if not quiet:
-                    print("Downloaded image %d/%d" % (k, totalnum))
+                    print(
+                        f"Downloaded image {str(k).zfill(len(str(totalnum)))}/{totalnum}"
+                    )
 
         if not quiet:
             print("Saving GeoTIFF. Please wait...")
@@ -749,7 +751,7 @@ def bbox_to_xy(
 
     Returns:
         list: A list of pixel coordinates in the format of [[minx, miny, maxx, maxy], ...]
-    """    
+    """
 
     if isinstance(coords, str):
         gdf = gpd.read_file(coords)
@@ -816,6 +818,8 @@ def bbox_to_xy(
     if len(result) == 0:
         print("No valid pixel coordinates found.")
         return None
+    elif len(result) == 1:
+        return result[0]
     elif len(result) < len(coords):
         print("Some coordinates are out of the image boundary.")
 

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -518,7 +518,6 @@ class SamGeo:
             return masks, scores, logits
 
     def show_map(self, **kwargs):
-
         return sam_map_gui(self, **kwargs)
 
     def image_to_image(self, image, **kwargs):

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -503,6 +503,9 @@ class SamGeo:
                     )
             point_labels = np.array(point_labels)
 
+        if isinstance(box, list) and point_crs is not None:
+            box = np.array(bbox_to_xy(self.image, box, point_crs))
+
         predictor = self.predictor
         masks, scores, logits = predictor.predict(
             point_coords, point_labels, box, mask_input, multimask_output, return_logits


### PR DESCRIPTION
Although SAM accepts multiple input points for segmenting objects. However, all points are treated as they belong to the same object, which results in bad segmentation results and over estimation. This PR adds a `predict_batch` function that will loops through each input point/bounding box to segment each object individually and merge the results as a single raster/vector. 

![image](https://github.com/opengeos/segment-geospatial/assets/5016453/2a9990f6-1343-4533-8ccc-e766c5cd0a41)
