### PR TITLE
Use proper extension in the usage documentation

### DIFF
--- a/docs/examples/satellite.ipynb
+++ b/docs/examples/satellite.ipynb
@@ -229,7 +229,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mask = \"segment.tiff\"\n",
+    "mask = \"segment.tif\"\n",
     "sam.generate(\n",
     "    image, mask, batch=True, foreground=True, erosion_kernel=(3, 3), mask_multiplier=255\n",
     ")"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,7 +30,7 @@ sam = SamGeo(
     sam_kwargs=None,
 )
 
-mask = 'segment.tiff'
+mask = 'segment.tif'
 sam.generate(image, mask)
 
 vector = 'segment.gpkg'


### PR DESCRIPTION
Usage documentation has a mask output with `.tiff` which doesn't fit the code logic in `common.array_to_image()` for tiffs.
this would ultimately break georeferencing, among other things.

Please accept this PR so other copy-pasters like me won't need to debug the internals ;)

thanks for the lib!
nas