### PR TITLE
Install and enable jupyter-server-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ LABEL maintainer="Qiusheng Wu"
 LABEL repo="https://github.com/opengeos/segment-geospatial"
 
 RUN mamba install -c conda-forge leafmap localtileserver segment-geospatial -y && \
-    pip install -U segment-geospatial && \
+    pip install -U segment-geospatial jupyter-server-proxy && \
+    jupyter serverextension enable --sys-prefix jupyter_server_proxy && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"
 


### PR DESCRIPTION
Necessary for leafmap.Map.add_raster to work in notebooks running via Docker Desktop (Windows) https://jupyter-server-proxy.readthedocs.io/en/latest/install.html