### PR TITLE
Add huggingface_hub and remove onnx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ segment-anything-py
 opencv-python 
 pycocotools 
 matplotlib 
-onnxruntime; python_version < '3.11'
-onnx
+huggingface_hub
 geopandas
 rasterio
 tqdm

--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -11,6 +11,7 @@ import torch
 from PIL import Image
 from segment_anything import sam_model_registry
 from segment_anything import SamPredictor
+from huggingface_hub import hf_hub_download
 from .common import *
 
 try:
@@ -29,7 +30,7 @@ try:
     from groundingdino.util.inference import predict
     from groundingdino.util.slconfig import SLConfig
     from groundingdino.util.utils import clean_state_dict
-    from huggingface_hub import hf_hub_download
+
 except ImportError:
     print("Installing GroundingDINO...")
     install_package("groundingdino-py")


### PR DESCRIPTION
This PR adds huggingface_hub and removes onnx and onnxruntime from requirements.txt.

I am adding supervision and groundingdino to conda-forge (https://github.com/conda-forge/staged-recipes/pull/22907). GroudingDINO can be added to requirements.txt once they become available on conda-forge. 