### PR TITLE
Add support for batch segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ The **segment-geospatial** package draws its inspiration from [segment-anything-
 -   [Automatically generating object masks](https://samgeo.gishub.org/examples/automatic_mask_generator)
 -   [Segmenting satellite imagery with input prompts](https://samgeo.gishub.org/examples/input_prompts)
 -   [Segmenting imagery with text prompts](https://samgeo.gishub.org/examples/text_prompts)
+-   [Batch segmentation with text prompts](https://samgeo.gishub.org/examples/text_prompts_batch)
 -   [Using segment-geospatial with ArcGIS Pro](https://samgeo.gishub.org/examples/arcgis)
+-   [Segmenting swimming pools with text prompts](https://samgeo.gishub.org/examples/swimming_pools)
 
 ## Demos
 

--- a/docs/examples/text_prompts_batch.ipynb
+++ b/docs/examples/text_prompts_batch.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batch segmentation with text prompts\n",
+    "\n",
+    "[![image](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/opengeos/segment-geospatial/blob/main/docs/examples/text_prompts_batch.ipynb)\n",
+    "[![image](https://img.shields.io/badge/Open-Planetary%20Computer-black?style=flat&logo=microsoft)](https://pccompute.westeurope.cloudapp.azure.com/compute/hub/user-redirect/git-pull?repo=https://github.com/opengeos/segment-geospatial&urlpath=lab/tree/segment-geospatial/docs/examples/text_prompts_batch.ipynb&branch=main)\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/segment-geospatial/blob/main/docs/examples/text_prompts_batch.ipynb)\n",
+    "\n",
+    "This notebook shows how to generate object masks from text prompts with the Segment Anything Model (SAM). \n",
+    "\n",
+    "Make sure you use GPU runtime for this notebook. For Google Colab, go to `Runtime` -> `Change runtime type` and select `GPU` as the hardware accelerator. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install dependencies\n",
+    "\n",
+    "Uncomment and run the following cell to install the required dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install segment-geospatial groundingdino-py leafmap localtileserver"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import leafmap\n",
+    "from samgeo import tms_to_geotiff, split_raster\n",
+    "from samgeo.text_sam import LangSAM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an interactive map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[-22.1278, -51.4430], zoom=17, height=\"800px\")\n",
+    "m.add_basemap(\"SATELLITE\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download a sample image\n",
+    "\n",
+    "Pan and zoom the map to select the area of interest. Use the draw tools to draw a polygon or rectangle on the map"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bbox = m.user_roi_bounds()\n",
+    "if bbox is None:\n",
+    "    bbox = [-51.4494, -22.1307, -51.4371, -22.1244]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image = \"Image.tif\"\n",
+    "tms_to_geotiff(output=image, bbox=bbox, zoom=19, source=\"Satellite\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also use your own image. Uncomment and run the following cell to use your own image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# image = '/path/to/your/own/image.tif'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display the downloaded image on the map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.layers[-1].visible = False\n",
+    "m.add_raster(image, layer_name=\"Image\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Split the image into tiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "split_raster(image, out_dir=\"tiles\", tile_size=(1000, 1000), overlap=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize LangSAM class\n",
+    "\n",
+    "The initialization of the LangSAM class might take a few minutes. The initialization downloads the model weights and sets up the model for inference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sam = LangSAM()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify text prompts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_prompt = \"tree\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Segment images\n",
+    "\n",
+    "Part of the model prediction includes setting appropriate thresholds for object detection and text association with the detected objects. These threshold values range from 0 to 1 and are set while calling the predict method of the LangSAM class.\n",
+    "\n",
+    "`box_threshold`: This value is used for object detection in the image. A higher value makes the model more selective, identifying only the most confident object instances, leading to fewer overall detections. A lower value, conversely, makes the model more tolerant, leading to increased detections, including potentially less confident ones.\n",
+    "\n",
+    "`text_threshold`: This value is used to associate the detected objects with the provided text prompt. A higher value requires a stronger association between the object and the text prompt, leading to more precise but potentially fewer associations. A lower value allows for looser associations, which could increase the number of associations but also introduce less precise matches.\n",
+    "\n",
+    "Remember to test different threshold values on your specific data. The optimal threshold can vary depending on the quality and nature of your images, as well as the specificity of your text prompts. Make sure to choose a balance that suits your requirements, whether that's precision or recall."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sam.predict_batch(\n",
+    "    images='tiles', \n",
+    "    out_dir='masks', \n",
+    "    text_prompt=text_prompt, \n",
+    "    box_threshold=0.24, \n",
+    "    text_threshold=0.24,\n",
+    "    mask_multiplier=255, \n",
+    "    dtype='uint8',\n",
+    "    merge=True,\n",
+    "    verbose=True\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_raster('masks/merged.tif', cmap='viridis', nodata=0, layer_name='Mask')\n",
+    "m.add_layer_manager()\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "![](https://i.imgur.com/JUhNkm6.png)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sam",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,9 @@ The **segment-geospatial** package draws its inspiration from [segment-anything-
 -   [Automatically generating object masks](https://samgeo.gishub.org/examples/automatic_mask_generator)
 -   [Segmenting satellite imagery with input prompts](https://samgeo.gishub.org/examples/input_prompts)
 -   [Segmenting imagery with text prompts](https://samgeo.gishub.org/examples/text_prompts)
+-   [Batch segmentation with text prompts](https://samgeo.gishub.org/examples/text_prompts_batch)
 -   [Using segment-geospatial with ArcGIS Pro](https://samgeo.gishub.org/examples/arcgis)
+-   [Segmenting swimming pools with text prompts](https://samgeo.gishub.org/examples/swimming_pools)
 
 ## Demos
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,8 +53,9 @@ nav:
           - examples/automatic_mask_generator.ipynb
           - examples/input_prompts.ipynb
           - examples/text_prompts.ipynb
-          - examples/arcgis.ipynb
+          - examples/text_prompts_batch.ipynb
           - examples/swimming_pools.ipynb
+          - examples/arcgis.ipynb
     - API Reference:
           - common module: common.md
           - samgeo module: samgeo.md


### PR DESCRIPTION
This PR adds support for batch segmentation with text prompts. This can be useful when an image is too large for the GPU. Splitting the image into smaller tiles and segmenting each tile and merge the results as a single GeoTIFF.

![](https://i.imgur.com/JUhNkm6.png)