### PR TITLE
Fix mask bug in text_sam/predict when the input is PIL image

### DIFF
--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -274,6 +274,7 @@ class LangSAM:
                 )  # Convert numpy array to PIL image, excluding the alpha channel
         else:
             image_pil = image
+            image_np = np.array(image_pil)
 
         self.image = image_pil
 


### PR DESCRIPTION
When the input is a PIL image, the text_sam/predict is unable to use the numpy image for mask generation
because no such thing exists. 

Fix: Probably it would be nicer to use dimensions from the PIL image, 
but the bugfix is easier to understand in this format.
