### PR TITLE
[FIX] Added missing conversions from BGR to RGB

### DIFF
--- a/samgeo/hq_sam.py
+++ b/samgeo/hq_sam.py
@@ -199,6 +199,7 @@ class SamGeo:
                 )
 
             image = cv2.imread(source)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         elif isinstance(source, np.ndarray):
             image = source
             source = None

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -196,6 +196,7 @@ class SamGeo:
                 )
 
             image = cv2.imread(source)
+            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
         elif isinstance(source, np.ndarray):
             image = source
             source = None


### PR DESCRIPTION
This PR added missing conversions from BGR to RGB after reading an input image using OpenCV.
I opened an issue #170 to report this bug.