### PR TITLE
Two speedups

### DIFF
--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -1135,7 +1135,7 @@ def tiff_to_tiff(
         profile = src.profile
 
         if nodata_value is None:
-            nodata_values = profile.get('nodata', None)
+            nodata_values = profile.get("nodata", None)
 
         # Computer blocks
         rh, rw = profile["height"], profile["width"]
@@ -1159,11 +1159,11 @@ def tiff_to_tiff(
             for b in tqdm(sample_grid):
                 # Read each tile from the source
                 r = read_block(src, **b)
-                
+
                 if nodata_value is not None:
-                    if (r==nodata_value).mean() >= sample_nodata_threshold:
+                    if (r == nodata_value).mean() >= sample_nodata_threshold:
                         continue
-                    
+
                 # Extract the first 3 channels as RGB
                 uint8_rgb_in = data_to_rgb(r)
                 orig_size = uint8_rgb_in.shape[:2]

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -152,6 +152,9 @@ class SamGeo:
         output=None,
         foreground=True,
         batch=False,
+        batch_sample_size=(512,512),
+        batch_nodata_threshold=1.0,
+        nodata_value=None,
         erosion_kernel=None,
         mask_multiplier=255,
         unique=True,
@@ -164,6 +167,12 @@ class SamGeo:
             output (str, optional): The path to the output image. Defaults to None.
             foreground (bool, optional): Whether to generate the foreground mask. Defaults to True.
             batch (bool, optional): Whether to generate masks for a batch of image tiles. Defaults to False.
+            batch_sample_size (tuple, optional): When batch=True, the size of the sample window when iterating over rasters. 
+            batch_nodata_threshold (float,optional): Batch samples with a fraction of nodata pixels above this threshold will
+                not be used to generate a mask. The default, 1.0, will skip samples with 100% nodata values. This is useful
+                when rasters have large areas of nodata values which can be skipped. 
+            nodata_value (int, optional): Nodata value to use in checking batch_nodata_threshold. The default, None,
+                will use the nodata value in the raster metadata if present. 
             erosion_kernel (tuple, optional): The erosion kernel for filtering object masks and extract borders.
                 Such as (3, 3) or (5, 5). Set to None to disable it. Defaults to None.
             mask_multiplier (int, optional): The mask multiplier for the output mask, which is usually a binary mask [0, 1].
@@ -190,6 +199,9 @@ class SamGeo:
                     output,
                     self,
                     foreground=foreground,
+                    sample_size=batch_sample_size,
+                    sample_nodata_threshold=batch_nodata_threshold,
+                    nodata_value=nodata_value,
                     erosion_kernel=erosion_kernel,
                     mask_multiplier=mask_multiplier,
                     **kwargs,

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -152,7 +152,7 @@ class SamGeo:
         output=None,
         foreground=True,
         batch=False,
-        batch_sample_size=(512,512),
+        batch_sample_size=(512, 512),
         batch_nodata_threshold=1.0,
         nodata_value=None,
         erosion_kernel=None,
@@ -167,12 +167,12 @@ class SamGeo:
             output (str, optional): The path to the output image. Defaults to None.
             foreground (bool, optional): Whether to generate the foreground mask. Defaults to True.
             batch (bool, optional): Whether to generate masks for a batch of image tiles. Defaults to False.
-            batch_sample_size (tuple, optional): When batch=True, the size of the sample window when iterating over rasters. 
+            batch_sample_size (tuple, optional): When batch=True, the size of the sample window when iterating over rasters.
             batch_nodata_threshold (float,optional): Batch samples with a fraction of nodata pixels above this threshold will
                 not be used to generate a mask. The default, 1.0, will skip samples with 100% nodata values. This is useful
-                when rasters have large areas of nodata values which can be skipped. 
+                when rasters have large areas of nodata values which can be skipped.
             nodata_value (int, optional): Nodata value to use in checking batch_nodata_threshold. The default, None,
-                will use the nodata value in the raster metadata if present. 
+                will use the nodata value in the raster metadata if present.
             erosion_kernel (tuple, optional): The erosion kernel for filtering object masks and extract borders.
                 Such as (3, 3) or (5, 5). Set to None to disable it. Defaults to None.
             mask_multiplier (int, optional): The mask multiplier for the output mask, which is usually a binary mask [0, 1].


### PR DESCRIPTION
Hi @giswqs, just suggesting two things which I found sped up processing time significantly on larger rasters.  

- allow the sample window size to be set from samgeo.generate. Fewer, larger windows take less time as long as you have the memory.
- Skip any sample windows which are 100% nodata, with the option to set lower thresholds.