### PR TITLE
Remove stray code block start in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ If your system has a GPU, but the above commands do not install the GPU version 
 mamba install -c conda-forge segment-geospatial "pytorch=*=cuda*"
 ```
 
-````bash
-
 Samgeo-geospatial has some optional dependencies that are not included in the default conda environment. To install these dependencies, run the following command:
 
 ```bash


### PR DESCRIPTION
The README has this extra code block start that makes this section render improperly.

Currently looks like:

![Screenshot 2024-04-22 at 10 21 26 AM](https://github.com/opengeos/segment-geospatial/assets/11656932/93843ced-7b75-4ac0-98df-9da6eb3294ba)

With the changes here:

![Screenshot 2024-04-22 at 10 21 42 AM](https://github.com/opengeos/segment-geospatial/assets/11656932/22825a25-c36d-4470-b6a8-68483f10f8e8)
