### PR TITLE
Added UserWarning when CRS of input image is None

### DIFF
--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -283,7 +283,7 @@ class LangSAM:
                         "before running segment-geospatial, "
                         "or manually set CRS on result object "
                         "like `sam.crs = 'EPSG:3857'`.",
-                        UserWarning
+                        UserWarning,
                     )
 
                 image_pil = Image.fromarray(

--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -274,6 +274,18 @@ class LangSAM:
                 )  # Convert rasterio image to numpy array
                 self.transform = src.transform  # Save georeferencing information
                 self.crs = src.crs  # Save the Coordinate Reference System
+
+                if self.crs is None:
+                    warnings.warn(
+                        "The CRS (Coordinate Reference System) "
+                        "of input image is None. "
+                        "Please define a projection on the input image "
+                        "before running segment-geospatial, "
+                        "or manually set CRS on result object "
+                        "like `sam.crs = 'EPSG:3857'`.",
+                        UserWarning
+                    )
+
                 image_pil = Image.fromarray(
                     image_np[:, :, :3]
                 )  # Convert numpy array to PIL image, excluding the alpha channel


### PR DESCRIPTION
Some functions within segment-geospatial don't rely on a valid CRS, but others like `save_boxes()` expects a valid CRS to be set before reprojecting to a `dst_crs`.  The source crs should be set by reading metadata from input image, but if not available, it would be helpful to see a warning while reading of the input image so you are not as surprised when `save_boxes` throws an error.