### PR TITLE
Add `detection_filter` to `predict()` method to allow for user-defined logic

### DIFF
--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -327,10 +327,14 @@ class LangSAM:
 
                 req_nargs = 6 if inspect.ismethod(detection_filter) else 5
                 if not len(inspect.signature(detection_filter).parameters) == req_nargs:
-                    raise ValueError("detection_filter required args: "
-                                     "box, mask, logit, phrase, and index.")
+                    raise ValueError(
+                        "detection_filter required args: "
+                        "box, mask, logit, phrase, and index."
+                    )
 
-            for i, (box, mask, logit, phrase) in enumerate(zip(boxes, masks, logits, phrases)):
+            for i, (box, mask, logit, phrase) in enumerate(
+                zip(boxes, masks, logits, phrases)
+            ):
 
                 # Convert tensor to numpy array if necessary and ensure it contains integers
                 if isinstance(mask, torch.Tensor):


### PR DESCRIPTION
Hey @giswqs...I was interested in being able to have finer-grain control over the filtering of detections, especially during `batch_predict`.

Just an idea, but what about adding a callable `detection_filter` arg to `predict()`? 

...which expects a function like:

```python
def max_25_detections_filter_func(box, mask, logit, phrase, i) -> bool:
    return i < 25
```

To then be passed in kwargs down the line...
```python 
sam.batch_predict(..., detection_filter=max_25_detections_filter_func) 
```

I've implemented the following above, and seems to work well, but would appreciate hearing other people's perspectives on the API for something like this.


