### PR TITLE
Add sam2 as a dependency

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,8 +15,6 @@ jobs:
             fail-fast: false
             matrix:
                 config:
-                    - { os: ubuntu-latest, py: "3.8" }
-                    - { os: ubuntu-latest, py: "3.9" }
                     - { os: ubuntu-latest, py: "3.10" }
                     - { os: ubuntu-latest, py: "3.11" }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ patool
 pycocotools
 pyproj
 rasterio
+sam2
 segment-anything-hq
 segment-anything-py
 timm


### PR DESCRIPTION
sam2 is now available on conda-forge. This PR adds sam2 as a dependency. Support for sam2 will be added later. 

https://anaconda.org/conda-forge/sam2