### PR TITLE
Remove hard coded model path in satellite example

### DIFF
--- a/docs/examples/satellite.ipynb
+++ b/docs/examples/satellite.ipynb
@@ -199,7 +199,6 @@
    "source": [
     "sam = SamGeo(\n",
     "    model_type=\"vit_h\",\n",
-    "    checkpoint=\"sam_vit_h_4b8939.pth\",\n",
     "    sam_kwargs=None,\n",
     ")"
    ]


### PR DESCRIPTION
Remove the hard coded model path in satellite example, so it is downloaded automatically like the other examples in the repo. Otherwise you need to wget the model manually / you get an exception because the model is missing when using the notebook.