### PR TITLE
Fix save masks bug

### DIFF
--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -265,8 +265,8 @@ class SamGeo:
 
         # Generate a mask of objects with unique values
         if unique:
-            # Sort the masks by area in ascending order
-            sorted_masks = sorted(masks, key=(lambda x: x["area"]), reverse=False)
+            # Sort the masks by area in descending order
+            sorted_masks = sorted(masks, key=(lambda x: x["area"]), reverse=True)
 
             # Create an output image with the same size as the input image
             objects = np.zeros(
@@ -276,9 +276,10 @@ class SamGeo:
                 )
             )
             # Assign a unique value to each object
+            count = len(sorted_masks)
             for index, ann in enumerate(sorted_masks):
                 m = ann["segmentation"]
-                objects[m] = index + 1
+                objects[m] = count - index
 
         # Generate a binary mask
         else:

--- a/samgeo/samgeo2.py
+++ b/samgeo/samgeo2.py
@@ -293,8 +293,8 @@ class SamGeo2:
 
         # Generate a mask of objects with unique values
         if unique:
-            # Sort the masks by area in ascending order
-            sorted_masks = sorted(masks, key=(lambda x: x["area"]), reverse=False)
+            # Sort the masks by area in descending order
+            sorted_masks = sorted(masks, key=(lambda x: x["area"]), reverse=True)
 
             # Create an output image with the same size as the input image
             objects = np.zeros(
@@ -304,9 +304,10 @@ class SamGeo2:
                 )
             )
             # Assign a unique value to each object
+            count = len(sorted_masks)
             for index, ann in enumerate(sorted_masks):
                 m = ann["segmentation"]
-                objects[m] = index + 1
+                objects[m] = count - index
 
         # Generate a binary mask
         else:


### PR DESCRIPTION
When saving the masks with unique ids, the large background objects overwrite the small objects inside, which is incorrect. This PR fixes it. 

Annotations:
![image](https://github.com/user-attachments/assets/3ded5160-1ee8-4162-a9d7-146a4e4702e2)

before the fix:
![image](https://github.com/user-attachments/assets/2409d50b-2002-4660-96a2-cb1bd067b5e8)

after the fix:
![image](https://github.com/user-attachments/assets/cc490e99-b838-4fad-8a72-1d16faf2c4b9)

