### PR TITLE
Add support for calculating geometric properties of objects

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,10 @@ patool
 pycocotools
 pyproj
 rasterio
+rioxarray
 sam2
+scikit-image
+scikit-learn
 segment-anything-hq
 segment-anything-py
 timm

--- a/samgeo/samgeo2.py
+++ b/samgeo/samgeo2.py
@@ -1514,3 +1514,57 @@ class SamGeo2:
         common.raster_to_vector(
             raster, vector, simplify_tolerance=simplify_tolerance, **kwargs
         )
+
+    def region_groups(
+        self,
+        image: Union[str, "xr.DataArray", np.ndarray],
+        connectivity: int = 1,
+        min_size: int = 10,
+        max_size: Optional[int] = None,
+        threshold: Optional[int] = None,
+        properties: Optional[List[str]] = None,
+        out_csv: Optional[str] = None,
+        out_vector: Optional[str] = None,
+        out_image: Optional[str] = None,
+        **kwargs: Any,
+    ) -> Union[
+        Tuple[np.ndarray, "pd.DataFrame"], Tuple["xr.DataArray", "pd.DataFrame"]
+    ]:
+        """
+        Segment regions in an image and filter them based on size.
+
+        Args:
+            image (Union[str, xr.DataArray, np.ndarray]): Input image, can be a file
+                path, xarray DataArray, or numpy array.
+            connectivity (int, optional): Connectivity for labeling. Defaults to 1
+                for 4-connectivity. Use 2 for 8-connectivity.
+            min_size (int, optional): Minimum size of regions to keep. Defaults to 10.
+            max_size (Optional[int], optional): Maximum size of regions to keep.
+                Defaults to None.
+            threshold (Optional[int], optional): Threshold for filling holes.
+                Defaults to None, which is equal to min_size.
+            properties (Optional[List[str]], optional): List of properties to measure.
+                See https://scikit-image.org/docs/stable/api/skimage.measure.html#skimage.measure.regionprops
+                Defaults to None.
+            out_csv (Optional[str], optional): Path to save the properties as a CSV file.
+                Defaults to None.
+            out_vector (Optional[str], optional): Path to save the vector file.
+                Defaults to None.
+            out_image (Optional[str], optional): Path to save the output image.
+                Defaults to None.
+
+        Returns:
+            Union[Tuple[np.ndarray, pd.DataFrame], Tuple[xr.DataArray, pd.DataFrame]]: Labeled image and properties DataFrame.
+        """
+        return common.region_groups(
+            image,
+            connectivity=connectivity,
+            min_size=min_size,
+            max_size=max_size,
+            threshold=threshold,
+            properties=properties,
+            out_csv=out_csv,
+            out_vector=out_vector,
+            out_image=out_image,
+            **kwargs,
+        )


### PR DESCRIPTION
This PR adds the `region_groups` function for filtering objects by size, filing holes, and calculating geometric properties of each object. 

![image](https://github.com/user-attachments/assets/acb625b5-c7d3-4ab2-b816-90cce382aae5)

![image](https://github.com/user-attachments/assets/3a13b23f-1e9c-46e7-84cb-0881708bae25)
