### PR TITLE
Dockerfile update to fix dependency issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,12 @@ FROM jupyter/base-notebook:latest
 LABEL maintainer="Qiusheng Wu"
 LABEL repo="https://github.com/opengeos/segment-geospatial"
 
+USER root
+RUN apt-get update -y && apt-get install libgl1 -y
+
+USER 1000
 RUN mamba install -c conda-forge leafmap localtileserver segment-geospatial -y && \
-    pip install -U segment-geospatial jupyter-server-proxy && \
+    pip install -U segment-geospatial jupyter-server-proxy backports.tarfile && \
     jupyter server extension enable --sys-prefix jupyter_server_proxy && \
     fix-permissions "${CONDA_DIR}" && \
     fix-permissions "/home/${NB_USER}"


### PR DESCRIPTION
This PR fixes two dependency issues with the current Dockerfile (which is based on Ubuntu 22.04.3 LTS)

- adds `libgl1` to fix `ImportError: libGL.so.1: cannot open shared object file`
- adds `backports.tarfile` to fix  `Exception: cannot import name 'tarfile' from 'backports'`