### PR TITLE
text_sam: Fixed issue when passing PIL Image as input to SamGeo2

### DIFF
--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -229,7 +229,12 @@ class LangSAM:
             )
             return masks.cpu()
         elif self._sam_version == 2:
-            self.sam.set_image(self.source)
+
+            if isinstance(self.source, str):
+                self.sam.set_image(self.source)
+            # If no source is set provide PIL image
+            if self.source is None:
+                self.sam.set_image(image)
             self.sam.boxes = boxes.numpy().tolist()
             masks, _, _ = self.sam.predict(
                 boxes=boxes.numpy().tolist(),


### PR DESCRIPTION
I'm adding a GRASS addon [i.sam2](https://github.com/OSGeo/grass-addons/pull/1244) and found this bug during implementation. The issue occurs when you pass a *PIL Image* as input to `LangSAM.predict`. During this case the image source is not set. However, this causes an issue when `LangSam.predict_sam` is called throwing a value error in `SamGeo2.set_image`.
