### PR TITLE
Make sam2 optional

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -28,6 +28,8 @@ jobs:
               uses: actions/setup-python@v5
               with:
                   python-version: ${{ matrix.config.py }}
+            - name: Set CUDA_HOME
+              run: echo "CUDA_HOME=/usr/local/cuda" >> $GITHUB_ENV
             - name: Install GDAL
               run: |
                   python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,11 +12,12 @@ pycocotools
 pyproj
 rasterio
 rioxarray
-# sam2
+sam2
 scikit-image
 scikit-learn
 segment-anything-hq
 segment-anything-py
+setuptools>=62.3.0,<75.9
 timm
 tqdm
 xarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pycocotools
 pyproj
 rasterio
 rioxarray
-sam2
+# sam2
 scikit-image
 scikit-learn
 segment-anything-hq

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 groundingdino-py
 rio-cogeo
+sam2
 segment-anything-fast

--- a/samgeo/samgeo2.py
+++ b/samgeo/samgeo2.py
@@ -6,9 +6,13 @@ import matplotlib.pyplot as plt
 from PIL.Image import Image
 from tqdm import tqdm
 from typing import Any, Dict, List, Optional, Tuple, Union
-from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
-from sam2.sam2_image_predictor import SAM2ImagePredictor
-from sam2.sam2_video_predictor import SAM2VideoPredictor
+
+try:
+    from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+    from sam2.sam2_image_predictor import SAM2ImagePredictor
+    from sam2.sam2_video_predictor import SAM2VideoPredictor
+except ImportError:
+    print("Please install sam2 using `pip install sam2`.")
 
 from . import common
 


### PR DESCRIPTION
Some recent Colab updates break the sam2 installation. As a result, sam2 can no longer be installed. This PR makes sam2 an optional dependency. 