### PR TITLE
Fix map interaction bug

### DIFF
--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -15,7 +15,7 @@ mkdocs-material>=9.1.3
 mkdocs-pdf-export-plugin
 mkdocstrings
 mkdocstrings-crystal
-mkdocstrings-python-legacy
+mkdocstrings-python
 nbconvert
 nbformat
 pip

--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -1893,12 +1893,14 @@ def sam_map_gui(sam, basemap="SATELLITE", repeat_mode=True, out_dir=None, **kwar
         style=style,
         layout=widgets.Layout(width=widget_width, padding=padding),
     )
+
     def on_radio_button_click(change):
-     # Set a flag to indicate UI interaction is happening
-     m._ui_interaction = True
-     # Use a small delay to reset the flag after the event is processed
-     import threading
-     threading.Timer(0.1, lambda: setattr(m, "_ui_interaction", False)).start()
+        # Set a flag to indicate UI interaction is happening
+        m._ui_interaction = True
+        # Use a small delay to reset the flag after the event is processed
+        import threading
+
+        threading.Timer(0.1, lambda: setattr(m, "_ui_interaction", False)).start()
 
     radio_buttons.observe(on_radio_button_click, "value")
 

--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -1893,14 +1893,14 @@ def sam_map_gui(sam, basemap="SATELLITE", repeat_mode=True, out_dir=None, **kwar
         style=style,
         layout=widgets.Layout(width=widget_width, padding=padding),
     )
-def on_radio_button_click(change):
-    # Set a flag to indicate UI interaction is happening
-    m._ui_interaction = True
-    # Use a small delay to reset the flag after the event is processed
-    import threading
-    threading.Timer(0.1, lambda: setattr(m, "_ui_interaction", False)).start()
+    def on_radio_button_click(change):
+     # Set a flag to indicate UI interaction is happening
+     m._ui_interaction = True
+     # Use a small delay to reset the flag after the event is processed
+     import threading
+     threading.Timer(0.1, lambda: setattr(m, "_ui_interaction", False)).start()
 
-radio_buttons.observe(on_radio_button_click, "value")
+    radio_buttons.observe(on_radio_button_click, "value")
 
     fg_count = widgets.IntText(
         value=0,

--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -1893,6 +1893,14 @@ def sam_map_gui(sam, basemap="SATELLITE", repeat_mode=True, out_dir=None, **kwar
         style=style,
         layout=widgets.Layout(width=widget_width, padding=padding),
     )
+def on_radio_button_click(change):
+    # Set a flag to indicate UI interaction is happening
+    m._ui_interaction = True
+    # Use a small delay to reset the flag after the event is processed
+    import threading
+    threading.Timer(0.1, lambda: setattr(m, "_ui_interaction", False)).start()
+
+radio_buttons.observe(on_radio_button_click, "value")
 
     fg_count = widgets.IntText(
         value=0,
@@ -2110,6 +2118,9 @@ def sam_map_gui(sam, basemap="SATELLITE", repeat_mode=True, out_dir=None, **kwar
     def handle_map_interaction(**kwargs):
         try:
             if kwargs.get("type") == "click":
+                # Skip if we're interacting with UI
+                if hasattr(m, "_ui_interaction") and m._ui_interaction:
+                    return
                 latlon = kwargs.get("coordinates")
                 if radio_buttons.value == "Foreground":
                     if is_colab():


### PR DESCRIPTION
Bug Description
On colab, When clicking on the background radio button in the SAM map GUI, an arbitrary point is added to the map at the location of the click. This happens because the map's click event handler is being triggered when interacting with UI elements.

Steps to Reproduce
Initialize the SAM map GUI
Click on the "Background" radio button
Observe that a point is added to the map at the location of the click
Expected Behavior
Clicking on the radio button should only change the selection mode without adding a point to the map.

Proposed Solution
The issue is in the handle_map_interaction function in common.py. The map's click event handler needs to be modified to ignore clicks that occur on UI elements.

I Tested on colab and working as expected