### PR TITLE
Update arcgis.ipynb

### DIFF
--- a/docs/examples/arcgis.ipynb
+++ b/docs/examples/arcgis.ipynb
@@ -1,8 +1,8 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Using the Segment-Geospatial Python Package with ArcGIS Pro\n",
     "\n",
@@ -163,7 +163,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "Segment the image and save the results to a GeoTIFF file. Set `unique=True` to assign a unique ID to each object."
+   "source": [
+    "Segment the image and save the results to a GeoTIFF file. Set `unique=True` to assign a unique ID to each object."
+   ]
   },
   {
    "cell_type": "code",

--- a/docs/examples/arcgis.ipynb
+++ b/docs/examples/arcgis.ipynb
@@ -1,8 +1,8 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
    "metadata": {},
+   "cell_type": "markdown",
    "source": [
     "# Using the Segment-Geospatial Python Package with ArcGIS Pro\n",
     "\n",
@@ -13,30 +13,17 @@
     "\n",
     "## Installation\n",
     "\n",
-    "1. Open Windows Registry Editor (`regedit.exe`) and navigate to `Computer\\HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\FileSystem`. Change the value of `LongPathsEnabled` to `1`. See [this screenshot](https://user-images.githubusercontent.com/46331011/225140182-df32dcfe-dca2-4e7f-9992-4c389af36184.png). This is a [known issue](https://github.com/Esri/deep-learning-frameworks/blob/master/README.md#known-issues) with the deep learning libraries for ArcGIS Pro 3.1. A future release might fix this issue.\n",
-    "2. Navigate to the **Start Menu** -> **All apps** -> **ArcGIS** folder, then open the **Python Command Prompt**.\n",
-    "3. Create a new conda environment and install [mamba](https://mamba.readthedocs.io/) and Python 3.9.x from the [Esri Anaconda channel](https://anaconda.org/Esri/repo). Mamba is a drop-in replacement for conda that is mach faster for installing Python packages and their dependencies. \n",
-    "   \n",
-    "    `conda create conda-forge::mamba esri::python --name geo`\n",
+    "1. Navigate to the **Start Menu** -> **All apps** -> **ArcGIS** folder, then open the **Python Command Prompt**.\n",
+    "2. Create a new conda environment and install dependencies.\n",
     "\n",
-    "4. Activate the new conda environment.\n",
+    "    `conda create esri::python esri::arcpy conda-forge::segment-geospatial --name geo`\n",
     "\n",
-    "    `conda activate geo`\n",
-    "\n",
-    "5. This step is optional. If you get an error message saying that `Download error (60) SSL peer certificate or SSH remote key was not OK` when installing packages in the next step, run the following command to fix the issue.\n",
-    "\n",
-    "    `conda config --set ssl_verify false`\n",
-    "\n",
-    "5. Install arcpy, deep-learning-essentials, segment-geospatial, and other dependencies (~4GB download).\n",
-    "\n",
-    "    `mamba install arcpy deep-learning-essentials segment-geospatial pygis -c esri -c conda-forge`\n",
-    "\n",
-    "6. Activate the new environment in ArcGIS Pro.\n",
+    "3. Activate the new environment in ArcGIS Pro.\n",
     "\n",
     "    `proswap geo`\n",
     "\n",
-    "7. Close the Python Command Prompt and open ArcGIS Pro.\n",
-    "8. [Download](https://samgeo.gishub.org/examples/arcgis/arcgis.ipynb) this notebook and run it in ArcGIS Pro."
+    "4. Close the Python Command Prompt and open ArcGIS Pro.\n",
+    "5. [Download](https://samgeo.gishub.org/examples/arcgis/arcgis.ipynb) this notebook and run it in ArcGIS Pro."
    ]
   },
   {
@@ -65,7 +52,7 @@
    "source": [
     "## Download sample data\n",
     "\n",
-    "In this example, we will use the high-resolution aerial imagery from the USDA National Agricultural Imagery Program ([NAIP](https://naip-usdaonline.hub.arcgis.com/)). You can download NAIP imagery using the [USDA Data Gateway](https://datagateway.nrcs.usda.gov/) or the [USDA NCRS Box Drive](https://nrcs.app.box.com/v/naip). I have downloaded some NAIP imagery and clipped them to a smaller area, which are available [here](https://github.com/opengeos/data/tree/main/naip). "
+    "In this example, we will use the high-resolution aerial imagery from the USDA National Agricultural Imagery Program ([NAIP](https://naip-usdaonline.hub.arcgis.com/)). You can download NAIP imagery using the [USDA Data Gateway](https://datagateway.nrcs.usda.gov/) or the [USDA NCRS Box Drive](https://nrcs.app.box.com/v/naip). I have downloaded some NAIP imagery and clipped them to a smaller area, which are available [here](https://github.com/opengeos/data/tree/main/naip)."
    ]
   },
   {
@@ -145,7 +132,7 @@
    "source": [
     "## Automatic mask generation\n",
     "\n",
-    "Specify the file path to the image we downloaded earlier. "
+    "Specify the file path to the image we downloaded earlier."
    ]
   },
   {
@@ -176,9 +163,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Segment the image and save the results to a GeoTIFF file. Set `unique=True` to assign a unique ID to each object. "
-   ]
+   "source": "Segment the image and save the results to a GeoTIFF file. Set `unique=True` to assign a unique ID to each object."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Updated conda install instructions. Anaconda now uses libmamba as the default solver, and Esri does not support the installation of deep-learning-essentials via conda. Tested in ArcGIS Pro 3.5.2.