### PR TITLE
feat: Optional imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Additionally, these other two optional imports are defined:
 Simply running the following should install the dependencies for each use case:
 
 ```bash
-pip install segment-geospatial[samgeo2] # Or any other choice of the above 
+pip install segment-geospatial[samgeo2] # Or any other choice of the above
 ```
 To see more in detail what packages come with each choice, please refer to `pyproject.toml`.
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,28 @@ The **segment-geospatial** package draws its inspiration from [segment-anything-
 
 ### Install from PyPI
 
-**segment-geospatial** is available on [PyPI](https://pypi.org/project/segment-geospatial/). To install **segment-geospatial**, run this command in your terminal:
+**segment-geospatial** is available on [PyPI](https://pypi.org/project/segment-geospatial/) and can be installed in several ways so that its dependencies can be controlled more granularly. This reduces package size for CI environments, since not every time all of the models will be used.
+
+Depending on what tools you need to use, you might want to do:
+* `segment-geospatial` or `segment-geospatial[samgeo]`: Installs only the minimum required dependencies to run SAMGeo
+* `segment-geospatial[samgeo2]`: Installs the dependencies to run SAMGeo 2
+* `segment-geospatial[fast]`: Installs the dependencies to run Fast SAM
+* `segment-geospatial[hq]`: Installs the dependencies to run HQ-SAM
+* `segment-geospatial[text]`: Installs Grounding DINO to use SAMGeo 1 and 2 with text prompts
+* `segment-geospatial[fer]`: Installs the dependencies to run the feature
+edge reconstruction algorithm
+
+Additionally, these other two optional imports are defined:
+* `segment-geospatial[all]`: Installs the dependencies to run all of the SAMGeo models
+* `segment-geospatial[extra]`: Installs the dependencies to run all of the SAMGeo models and other utilities to run the examples like Jupyter notebook support, `leafmap`, etc.
+
+Simply running the following should install the dependencies for each use case:
 
 ```bash
-pip install segment-geospatial
+pip install segment-geospatial[samgeo2] # Or any other choice of the above 
 ```
+To see more in detail what packages come with each choice, please refer to `pyproject.toml`.
+
 
 ### Install from conda-forge
 

--- a/docs/examples/automatic_mask_generator.ipynb
+++ b/docs/examples/automatic_mask_generator.ipynb
@@ -40,9 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo import SamGeo, show_image, download_file, overlay_images, tms_to_geotiff"
+    "from samgeo import SamGeo\n",
+    "from samgeo.common import overlay_images, tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/automatic_mask_generator_hq.ipynb
+++ b/docs/examples/automatic_mask_generator_hq.ipynb
@@ -36,15 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo.hq_sam import (\n",
-    "    SamGeo,\n",
-    "    show_image,\n",
-    "    download_file,\n",
-    "    overlay_images,\n",
-    "    tms_to_geotiff,\n",
-    ")"
+    "from samgeo.hq_sam import SamGeo\n",
+    "from samgeo.common import overlay_images, tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/box_prompts.ipynb
+++ b/docs/examples/box_prompts.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import tms_to_geotiff\n",
+    "from samgeo.common import tms_to_geotiff\n",
     "from samgeo import SamGeo"
    ]
   },

--- a/docs/examples/fast_sam.ipynb
+++ b/docs/examples/fast_sam.ipynb
@@ -39,8 +39,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import tms_to_geotiff\n",
-    "from samgeo.fast_sam import SamGeo"
+    "from samgeo.common import tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/input_prompts.ipynb
+++ b/docs/examples/input_prompts.ipynb
@@ -40,9 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo import SamGeo, tms_to_geotiff"
+    "from samgeo import SamGeo\n",
+    "from samgeo.common import tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/input_prompts_hq.ipynb
+++ b/docs/examples/input_prompts_hq.ipynb
@@ -38,9 +38,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo.hq_sam import SamGeo, tms_to_geotiff"
+    "from samgeo.hq_sam import SamGeo\n",
+    "from samgeo.common import tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/maxar_open_data.ipynb
+++ b/docs/examples/maxar_open_data.ipynb
@@ -41,9 +41,9 @@
    },
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo import SamGeo, raster_to_vector, overlay_images"
+    "from samgeo import SamGeo\n",
+    "from samgeo.common import raster_to_vector, overlay_images"
    ]
   },
   {

--- a/docs/examples/sam2_box_prompts.ipynb
+++ b/docs/examples/sam2_box_prompts.ipynb
@@ -39,7 +39,8 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import SamGeo2, raster_to_vector, regularize"
+    "from samgeo import SamGeo2\n",
+    "from samgeo.common import raster_to_vector, regularize"
    ]
   },
   {

--- a/docs/examples/sam2_point_prompts.ipynb
+++ b/docs/examples/sam2_point_prompts.ipynb
@@ -46,7 +46,8 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import SamGeo2, regularize"
+    "from samgeo import SamGeo2\n",
+    "from samgeo.common import regularize"
    ]
   },
   {

--- a/docs/examples/satellite-predictor.ipynb
+++ b/docs/examples/satellite-predictor.ipynb
@@ -54,7 +54,8 @@
    "source": [
     "import os\n",
     "import leafmap\n",
-    "from samgeo import SamGeoPredictor, tms_to_geotiff, get_basemaps\n",
+    "from samgeo import SamGeoPredictor\n",
+    "from samgeo.common import tms_to_geotiff\n",
     "from segment_anything import sam_model_registry"
    ]
   },

--- a/docs/examples/satellite.ipynb
+++ b/docs/examples/satellite.ipynb
@@ -50,9 +50,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
-    "from samgeo import SamGeo, tms_to_geotiff, get_basemaps"
+    "from samgeo import SamGeo\n",
+    "from samgeo.common import tms_to_geotiff"
    ]
   },
   {

--- a/docs/examples/text_prompts.ipynb
+++ b/docs/examples/text_prompts.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import tms_to_geotiff\n",
+    "from samgeo.common import tms_to_geotiff\n",
     "from samgeo.text_sam import LangSAM"
    ]
   },

--- a/docs/examples/text_prompts_batch.ipynb
+++ b/docs/examples/text_prompts_batch.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import tms_to_geotiff, split_raster\n",
+    "from samgeo.common import tms_to_geotiff, split_raster\n",
     "from samgeo.text_sam import LangSAM"
    ]
   },

--- a/docs/examples/text_swimming_pools.ipynb
+++ b/docs/examples/text_swimming_pools.ipynb
@@ -39,7 +39,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
-    "from samgeo import tms_to_geotiff\n",
+    "from samgeo.common import tms_to_geotiff\n",
     "from samgeo.text_sam import LangSAM"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ samgeo = [
 ]
 samgeo2 = [
     "opencv-python-headless",
+    "segment_anything",
     "Pillow",
     "torch",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "segment-geospatial"
-version = "0.13.0"
+version = "0.12.6"
 dynamic = [
     "dependencies",
 ]
@@ -42,7 +42,7 @@ core = [
 ]
 fast = [
     "segment_geospatial[core]",
-    "segment-anything-fast",
+    "segment-anything-fast@git+https://github.com/guillemc23/FastSAM#egg=d55a7b1cf8c04deff4bd2498c3fd61d1357f47d3",
     "sam2",
     ]
 fer = [
@@ -96,7 +96,7 @@ dependencies = {file = ["requirements.txt"]}
 universal = true
 
 [tool.bumpversion]
-current_version = "0.13.0"
+current_version = "0.12.6"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ core = [
 ]
 fast = [
     "segment_geospatial[core]",
-    "segment-anything-fast,
+    "segment-anything-fast",
     "sam2",
     ]
 fer = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ core = [
 ]
 fast = [
     "segment_geospatial[core]",
-    "segment-anything-fast@git+https://github.com/guillemc23/FastSAM#egg=d55a7b1cf8c04deff4bd2498c3fd61d1357f47d3",
+    "segment-anything-fast,
     "sam2",
     ]
 fer = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "segment-geospatial"
-version = "0.12.6"
+version = "0.13.0"
 dynamic = [
     "dependencies",
 ]
@@ -26,7 +26,92 @@ classifiers = [
 authors = [{name = "Qiusheng Wu", email = "giswqs@gmail.com"}]
 
 [project.optional-dependencies]
-all = ["groundingdino-py"]
+all = ["leafmap",
+    "rasterio",
+    "geopandas",
+    "shapely>=2.1.1",
+    "fiona",
+    "tqdm",
+    "numpy",
+    "torch",
+    "torchvision",
+    "Pillow",
+    "matplotlib",
+    "scikit-image",
+    "scipy",
+    "opencv-python-headless",
+    "pyproj>=3.7.2",
+    "segment-anything-fast",
+    "gdal",
+    "segment_anything",
+    "segment_anything_hq",
+    "sam2",
+    "matplotlib", # some functions require matplotlib for visualization
+    "huggingface_hub",
+    "groundingdino-py"
+    ]
+core = [
+    "rasterio",
+    "geopandas",
+    "shapely>=2.1.1",
+    "fiona",
+    "tqdm",
+    "numpy",
+    "torch",
+    "torchvision",
+    "Pillow",
+    "matplotlib",
+    "scikit-image",
+    "scipy",
+    "opencv-python-headless",
+    "pyproj>=3.7.2",
+    "segment-anything-fast"
+]
+fer = [
+    "gdal",
+    "shapely>=2.1.1",
+    ]
+hq = [
+    "segment_anything",
+    "segment_anything_hq",
+    "python-opencv-headless",
+    "torch",
+    "numpy",
+    "matplotlib", # some functions require matplotlib for visualization
+    ]
+samgeo = [
+    "python-opencv-headless",
+    "geopandas",
+    "numpy",
+    "torch",
+    "segment_anything",
+    "matplotlib", # some functions require matplotlib for visualization
+]
+samgeo2 = [
+    "python-opencv-headless",
+    "Pillow",
+    "torch",
+    "numpy",
+    "tqdm",
+    "sam2",
+    "matplotlib", # some functions require matplotlib for visualization
+]
+text = [
+    "numpy",
+    "torch",
+    "huggingface_hub",
+    "Pillow",
+    "segment_anything",
+    "python-opencv-headless",
+    "Pillow",
+    "torch",
+    "numpy",
+    "tqdm",
+    "sam2",
+    "rasterio",
+    "groundingdino-py",
+    "matplotlib", # some functions require matplotlib for visualization
+]
 
 [tool]
 [tool.setuptools.packages.find]
@@ -41,7 +126,7 @@ dependencies = {file = ["requirements.txt"]}
 universal = true
 
 [tool.bumpversion]
-current_version = "0.12.6"
+current_version = "0.13.0"
 commit = true
 tag = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 authors = [{name = "Qiusheng Wu", email = "giswqs@gmail.com"}]
 
 [project.optional-dependencies]
-all = ["leafmap",
+all_deps = ["leafmap",
     "rasterio",
     "geopandas",
     "shapely>=2.1.1",
@@ -50,6 +50,14 @@ all = ["leafmap",
     "huggingface_hub",
     "groundingdino-py"
     ]
+all = [
+    "leafmap",
+    "segment-geospatial[fast, hq, fer, samgeo, samgeo2, text]",
+    "localtileserver",
+    "ipykernel",
+    "fiona",
+    "matplotlib", # some functions require matplotlib for visualization
+    ]
 core = [
     "rasterio",
     "geopandas",
@@ -65,8 +73,13 @@ core = [
     "scipy",
     "opencv-python-headless",
     "pyproj>=3.7.2",
-    "segment-anything-fast"
 ]
+fast = [
+    "opencv-python-headless",
+    "numpy",
+    "torch",
+    "segment-anything-fast",
+    ]
 fer = [
     "gdal",
     "shapely>=2.1.1",
@@ -77,7 +90,6 @@ hq = [
     "opencv-python-headless",
     "torch",
     "numpy",
-    "matplotlib", # some functions require matplotlib for visualization
     ]
 samgeo = [
     "opencv-python-headless",
@@ -85,33 +97,21 @@ samgeo = [
     "numpy",
     "torch",
     "segment_anything",
-    "matplotlib", # some functions require matplotlib for visualization
+    "huggingface_hub",
 ]
 samgeo2 = [
-    "opencv-python-headless",
-    "segment_anything",
+    "segment_geospatial[samgeo]",
     "Pillow",
-    "torch",
-    "numpy",
-    "tqdm",
     "sam2",
-    "matplotlib", # some functions require matplotlib for visualization
+    "huggingface_hub",
+    "xarray",
+    "rioxarray",
+    "scikit-image",
+    "scipy",
 ]
 text = [
-    "numpy",
-    "torch",
-    "huggingface_hub",
-    "Pillow",
-    "segment_anything",
-    "opencv-python-headless",
-    "Pillow",
-    "torch",
-    "numpy",
-    "tqdm",
-    "sam2",
-    "rasterio",
+    "segment_geospatial[samgeo2]",
     "groundingdino-py",
-    "matplotlib", # some functions require matplotlib for visualization
 ]
 
 [tool]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,13 +74,13 @@ fer = [
 hq = [
     "segment_anything",
     "segment_anything_hq",
-    "python-opencv-headless",
+    "opencv-python-headless",
     "torch",
     "numpy",
     "matplotlib", # some functions require matplotlib for visualization
     ]
 samgeo = [
-    "python-opencv-headless",
+    "opencv-python-headless",
     "geopandas",
     "numpy",
     "torch",
@@ -88,7 +88,7 @@ samgeo = [
     "matplotlib", # some functions require matplotlib for visualization
 ]
 samgeo2 = [
-    "python-opencv-headless",
+    "opencv-python-headless",
     "Pillow",
     "torch",
     "numpy",
@@ -102,7 +102,7 @@ text = [
     "huggingface_hub",
     "Pillow",
     "segment_anything",
-    "python-opencv-headless",
+    "opencv-python-headless",
     "Pillow",
     "torch",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,84 +26,42 @@ classifiers = [
 authors = [{name = "Qiusheng Wu", email = "giswqs@gmail.com"}]
 
 [project.optional-dependencies]
-all_deps = ["leafmap",
-    "rasterio",
-    "geopandas",
-    "shapely>=2.1.1",
-    "fiona",
-    "tqdm",
-    "numpy",
-    "torch",
-    "torchvision",
-    "Pillow",
-    "matplotlib",
-    "scikit-image",
-    "scipy",
-    "opencv-python-headless",
-    "pyproj>=3.7.2",
-    "segment-anything-fast",
-    "gdal",
-    "segment_anything",
-    "segment_anything_hq",
-    "sam2",
-    "matplotlib", # some functions require matplotlib for visualization
-    "huggingface_hub",
-    "groundingdino-py"
-    ]
-all = [
-    "leafmap",
-    "segment-geospatial[fast, hq, fer, samgeo, samgeo2, text]",
-    "localtileserver",
-    "ipykernel",
-    "fiona",
-    "matplotlib", # some functions require matplotlib for visualization
-    ]
 core = [
-    "rasterio",
+    "gdown",
     "geopandas",
-    "shapely>=2.1.1",
-    "fiona",
-    "tqdm",
     "numpy",
-    "torch",
-    "torchvision",
-    "Pillow",
-    "matplotlib",
-    "scikit-image",
-    "scipy",
     "opencv-python-headless",
+    "patool",
+    "Pillow",
     "pyproj>=3.7.2",
+    "rasterio",
+    "segment_anything",
+    "shapely",
+    "torch",
+    "tqdm",
 ]
 fast = [
-    "opencv-python-headless",
-    "numpy",
-    "torch",
+    "segment_geospatial[core]",
     "segment-anything-fast",
+    "sam2",
     ]
 fer = [
+    "segment_geospatial[core]",
     "gdal",
-    "shapely>=2.1.1",
     ]
 hq = [
-    "segment_anything",
+    "segment_geospatial[core]",
     "segment_anything_hq",
-    "opencv-python-headless",
-    "torch",
-    "numpy",
+    "sam2",
+    "timm",
     ]
 samgeo = [
-    "opencv-python-headless",
-    "geopandas",
-    "numpy",
-    "torch",
-    "segment_anything",
+    "segment_geospatial[core]",
     "huggingface_hub",
 ]
 samgeo2 = [
     "segment_geospatial[samgeo]",
-    "Pillow",
     "sam2",
-    "huggingface_hub",
     "xarray",
     "rioxarray",
     "scikit-image",
@@ -112,6 +70,17 @@ samgeo2 = [
 text = [
     "segment_geospatial[samgeo2]",
     "groundingdino-py",
+]
+all = [
+    "segment-geospatial[fast, hq, fer, samgeo, samgeo2, text]",
+]
+extra = [
+    "leafmap",
+    "segment-geospatial[all]",
+    "localtileserver",
+    "ipykernel",
+    "fiona",
+    "matplotlib",
 ]
 
 [tool]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # fiona
 # gdown
-# geopandas
+geopandas
 # huggingface_hub
 # ipympl
 # leafmap
@@ -10,7 +10,7 @@
 # patool
 # pycocotools
 # pyproj
-# rasterio
+rasterio
 # rioxarray
 # sam2
 # scikit-image
@@ -18,6 +18,6 @@
 # segment-anything-hq
 # segment-anything-py
 # timm
-# tqdm
+tqdm
 # xarray
 # xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,23 +1,23 @@
-fiona
-gdown
-geopandas
-huggingface_hub
-ipympl
+# fiona
+# gdown
+# geopandas
+# huggingface_hub
+# ipympl
 # leafmap
 # localtileserver
-matplotlib
-opencv-python-headless
-patool
-pycocotools
-pyproj
-rasterio
-rioxarray
-sam2
-scikit-image
-scikit-learn
-segment-anything-hq
-segment-anything-py
-timm
-tqdm
-xarray
+# matplotlib
+# opencv-python-headless
+# patool
+# pycocotools
+# pyproj
+# rasterio
+# rioxarray
+# sam2
+# scikit-image
+# scikit-learn
+# segment-anything-hq
+# segment-anything-py
+# timm
+# tqdm
+# xarray
 # xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ rasterio
 segment_anything
 shapely
 torch
+torchvision
 tqdm
 xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,18 @@
+geopandas
+numpy
+opencv-python-headless
+rasterio
+tqdm
 # fiona
 # gdown
-geopandas
 # huggingface_hub
 # ipympl
 # leafmap
 # localtileserver
 # matplotlib
-# opencv-python-headless
 # patool
 # pycocotools
 # pyproj
-rasterio
 # rioxarray
 # sam2
 # scikit-image
@@ -18,6 +20,5 @@ rasterio
 # segment-anything-hq
 # segment-anything-py
 # timm
-tqdm
 # xarray
 # xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 gdown
 geopandas
+huggingface_hub
 numpy
 opencv-python-headless
 patool

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ gdown
 geopandas
 huggingface_hub
 ipympl
-leafmap
-localtileserver
+# leafmap
+# localtileserver
 matplotlib
 opencv-python-headless
 patool
@@ -20,4 +20,4 @@ segment-anything-py
 timm
 tqdm
 xarray
-xyzservices
+# xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ segment_anything
 shapely
 torch
 tqdm
+xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,12 @@
+gdown
 geopandas
 numpy
 opencv-python-headless
+patool
+Pillow
+pyproj>=3.7.2
 rasterio
+segment_anything
+shapely
+torch
 tqdm
-# fiona
-# gdown
-# huggingface_hub
-# ipympl
-# leafmap
-# localtileserver
-# matplotlib
-# patool
-# pycocotools
-# pyproj
-# rioxarray
-# sam2
-# scikit-image
-# scikit-learn
-# segment-anything-hq
-# segment-anything-py
-# timm
-# xarray
-# xyzservices

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ numpy
 opencv-python-headless
 patool
 Pillow
-pyproj>=3.7.2
+pyproj
 rasterio
 segment_anything
 shapely

--- a/samgeo/__init__.py
+++ b/samgeo/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.13.0"
+__version__ = "0.12.6"
 
 
 from .samgeo import *  # noqa: F403

--- a/samgeo/__init__.py
+++ b/samgeo/__init__.py
@@ -2,9 +2,9 @@
 
 __author__ = """Qiusheng Wu"""
 __email__ = "giswqs@gmail.com"
-__version__ = "0.12.6"
+__version__ = "0.13.0"
 
 
-from .samgeo import *
-from .samgeo2 import *
-from .common import show_image_gui
+from .common import show_image_gui  # noqa: F401
+from .samgeo import *  # noqa: F403
+from .samgeo2 import *  # noqa: F403

--- a/samgeo/__init__.py
+++ b/samgeo/__init__.py
@@ -5,6 +5,5 @@ __email__ = "giswqs@gmail.com"
 __version__ = "0.13.0"
 
 
-from .common import show_image_gui  # noqa: F401
 from .samgeo import *  # noqa: F403
 from .samgeo2 import *  # noqa: F403

--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -3962,9 +3962,9 @@ def orthogonalize(filepath, output=None, maxAngleChange=15, skewTolerance=15):
             limit[dirAngle[i]] = (
                 maxAngleChange  # Set angle limit for the current direction
             )
-            limit[
-                (dirAngle[i] + 1) % 4
-            ] = -maxAngleChange  # Extend the angles for the adjacent directions
+            limit[(dirAngle[i] + 1) % 4] = (
+                -maxAngleChange
+            )  # Extend the angles for the adjacent directions
             limit[(dirAngle[i] - 1) % 4] = -maxAngleChange
 
         return orgAngle, corAngle, dirAngle
@@ -4085,7 +4085,9 @@ def orthogonalize(filepath, output=None, maxAngleChange=15, skewTolerance=15):
             # Adjust points coordinates by taking the average of points in segment
             dirAngle.append(dirAngle[0])  # Append dummy value
             orgAngle.append(orgAngle[0])  # Append dummy value
-            segmentBuffer = []  # Buffer for determining which segments are part of one large straight line
+            segmentBuffer = (
+                []
+            )  # Buffer for determining which segments are part of one large straight line
 
             for i in range(0, len(dirAngle) - 1):
                 # Preserving skewed walls: Leave walls that are obviously meant to be skewed 45˚+/- tolerance˚ (e.g.angle 30-60 degrees) off main walls as untouched

--- a/samgeo/fast_sam.py
+++ b/samgeo/fast_sam.py
@@ -2,17 +2,26 @@
 https://github.com/opengeos/FastSAM
 """
 
-import matplotlib.pyplot as plt
+import os
+
+import cv2
 import numpy as np
 import torch
-from .common import *
+
+from samgeo.common import (
+    array_to_image,
+    download_file,
+    raster_to_vector,
+    show_image,
+    temp_file_path,
+)
 
 try:
     from fastsam import FastSAM, FastSAMPrompt
-except ImportError:
-    print("FastSAM not installed. Installing...")
-    install_package("segment-anything-fast")
-    from fastsam import FastSAM, FastSAMPrompt
+except ImportError as e:
+    print(
+        f"There was an error importing {e.name}. To use FAST-SAM, install it as:\n\tpip install segment-geospatial[fast]"
+    )
 
 
 class SamGeo(FastSAM):

--- a/samgeo/hq_sam.py
+++ b/samgeo/hq_sam.py
@@ -4,16 +4,51 @@ See https://github.com/SysCV/sam-hq
 """
 
 import os
-import cv2
-import torch
-import numpy as np
-from segment_anything_hq import (
-    sam_model_registry,
-    SamAutomaticMaskGenerator,
-    SamPredictor,
-)
 
-from .common import *
+import cv2
+import geopandas as gpd
+import numpy as np
+import torch
+
+try:
+    from segment_anything_hq import (
+        SamAutomaticMaskGenerator,
+        SamPredictor,
+        sam_model_registry,
+    )
+except ImportError as e:
+    print(
+        f"There was an error importing {e.name}. To use HQ-SAM, install it as:\n\tpip install segment-geospatial[hq]"
+    )
+
+
+from samgeo.common import (
+    array_to_image,
+    bbox_to_xy,
+    blend_images,
+    coords_to_xy,
+    download_checkpoint,
+    download_file,
+    draw_tile,
+    geojson_to_coords,
+    get_crs,
+    get_features,
+    get_pixel_coords,
+    get_profile,
+    image_to_image,
+    raster_to_geojson,
+    raster_to_gpkg,
+    raster_to_shp,
+    raster_to_vector,
+    sam_map_gui,
+    set_transform,
+    show_canvas,
+    tiff_to_tiff,
+    transform_coords,
+    vector_to_geojson,
+    write_features,
+    write_raster,
+)
 
 
 class SamGeo:

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -3,12 +3,40 @@ The source code is adapted from https://github.com/aliaksandr960/segment-anythin
 """
 
 import os
-import cv2
-import torch
-import numpy as np
-from segment_anything import sam_model_registry, SamAutomaticMaskGenerator, SamPredictor
 
-from .common import *
+import cv2
+import geopandas as gpd
+import numpy as np
+import torch
+from segment_anything import SamAutomaticMaskGenerator, SamPredictor, sam_model_registry
+
+from samgeo.common import (
+    array_to_image,
+    bbox_to_xy,
+    blend_images,
+    coords_to_xy,
+    download_checkpoint,
+    download_file,
+    draw_tile,
+    geojson_to_coords,
+    get_crs,
+    get_features,
+    get_pixel_coords,
+    get_profile,
+    image_to_image,
+    raster_to_geojson,
+    raster_to_gpkg,
+    raster_to_shp,
+    raster_to_vector,
+    sam_map_gui,
+    set_transform,
+    show_canvas,
+    tiff_to_tiff,
+    transform_coords,
+    vector_to_geojson,
+    write_features,
+    write_raster,
+)
 
 
 class SamGeo:

--- a/samgeo/samgeo2.py
+++ b/samgeo/samgeo2.py
@@ -1,16 +1,22 @@
 import os
+from typing import Any, Dict, List, Optional, Tuple, Union
+
 import cv2
-import torch
 import numpy as np
-import matplotlib.pyplot as plt
+import torch
 from PIL.Image import Image
 from tqdm import tqdm
-from typing import Any, Dict, List, Optional, Tuple, Union
-from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
-from sam2.sam2_image_predictor import SAM2ImagePredictor
-from sam2.sam2_video_predictor import SAM2VideoPredictor
 
-from . import common
+try:
+    from sam2.automatic_mask_generator import SAM2AutomaticMaskGenerator
+    from sam2.sam2_image_predictor import SAM2ImagePredictor
+    from sam2.sam2_video_predictor import SAM2VideoPredictor
+except ImportError as e:
+    print(
+        f"There was an error importing {e.name}. To use SAMGeo 2, install it as:\n\tpip install segment-geospatial[samgeo2]"
+    )
+
+from samgeo import common
 
 
 class SamGeo2:
@@ -1241,7 +1247,6 @@ class SamGeo2:
             if video_path.startswith("http"):
                 video_path = common.download_file(video_path)
             if os.path.isfile(video_path):
-
                 if output_dir is None:
                     output_dir = common.make_temp_dir()
                     if not os.path.exists(output_dir):
@@ -1329,7 +1334,6 @@ class SamGeo2:
         predictor = self.predictor
         inference_state = self.inference_state
         for obj_id, prompt in prompts.items():
-
             points = prompt.get("points", None)
             labels = prompt.get("labels", None)
             box = prompt.get("box", None)
@@ -1451,7 +1455,7 @@ class SamGeo2:
             output_video (Optional[str]): The path to the output video file. Defaults to None.
             fps (int): The frames per second for the output video. Defaults to 30.
         """
-
+        import matplotlib.pyplot as plt
         from PIL import Image
 
         def show_mask(mask, ax, obj_id=None, random_color=False):
@@ -1552,6 +1556,7 @@ class SamGeo2:
 
         """
 
+        import matplotlib.pyplot as plt
         from PIL import Image
 
         def show_mask(mask, ax, obj_id=None, random_color=random_color):

--- a/samgeo/text_sam.py
+++ b/samgeo/text_sam.py
@@ -7,23 +7,34 @@ import argparse
 import inspect
 import os
 import warnings
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
-from PIL import Image
-from segment_anything import sam_model_registry
-from segment_anything import SamPredictor
 from huggingface_hub import hf_hub_download
-from .common import *
+from PIL import Image
+from segment_anything import SamPredictor, sam_model_registry
+
+from samgeo.common import (
+    array_to_image,
+    boxes_to_vector,
+    download_file,
+    install_package,
+    merge_rasters,
+    raster_to_vector,
+    rowcol_to_xy,
+    text_sam_gui,
+)
+
 from .samgeo2 import SamGeo2
+
+warnings.filterwarnings("ignore")
 
 try:
     import rasterio
 except ImportError:
     print("Installing rasterio...")
     install_package("rasterio")
-
-warnings.filterwarnings("ignore")
 
 
 try:
@@ -229,7 +240,6 @@ class LangSAM:
             )
             return masks.cpu()
         elif self._sam_version == 2:
-
             if isinstance(self.source, str):
                 self.sam.set_image(self.source)
             # If no source is set provide PIL image
@@ -362,7 +372,6 @@ class LangSAM:
 
             # Validate the detection_filter argument
             if detection_filter is not None:
-
                 if not callable(detection_filter):
                     raise ValueError("detection_filter must be callable.")
 
@@ -375,7 +384,6 @@ class LangSAM:
             for i, (box, mask, logit, phrase) in enumerate(
                 zip(boxes, masks, logits, phrases)
             ):
-
                 # Convert tensor to numpy array if necessary and ensure it contains integers
                 if isinstance(mask, torch.Tensor):
                     mask = (
@@ -460,7 +468,7 @@ class LangSAM:
             basename = os.path.splitext(os.path.basename(image))[0]
             if verbose:
                 print(
-                    f"Processing image {str(i+1).zfill(len(str(len(images))))} of {len(images)}: {image}..."
+                    f"Processing image {str(i + 1).zfill(len(str(len(images))))} of {len(images)}: {image}..."
                 )
             output = os.path.join(out_dir, f"{basename}_mask.tif")
             self.predict(
@@ -532,8 +540,9 @@ class LangSAM:
         """
 
         import warnings
-        import matplotlib.pyplot as plt
+
         import matplotlib.patches as patches
+        import matplotlib.pyplot as plt
 
         warnings.filterwarnings("ignore")
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,7 +5,7 @@
 import os
 import unittest
 
-from samgeo import samgeo
+from samgeo import common
 
 
 class TestCommon(unittest.TestCase):
@@ -18,17 +18,17 @@ class TestCommon(unittest.TestCase):
         """Tear down test fixtures, if any."""
 
     def test_is_colab(self):
-        self.assertFalse(samgeo.is_colab())
+        self.assertFalse(common.is_colab())
 
     def test_check_file_path(self):
-        self.assertTrue(samgeo.check_file_path("tests/test_common.py"))
+        self.assertTrue(common.check_file_path("tests/test_common.py"))
 
     def test_temp_file_path(self):
-        self.assertFalse(os.path.exists(samgeo.temp_file_path(extension=".tif")))
+        self.assertFalse(os.path.exists(common.temp_file_path(extension=".tif")))
 
     def test_github_raw_url(self):
         self.assertEqual(
-            samgeo.github_raw_url(
+            common.github_raw_url(
                 "https://github.com/opengeos/segment-geospatial/blob/main/samgeo/samgeo.py"
             ),
             "https://raw.githubusercontent.com/opengeos/segment-geospatial/main/samgeo/samgeo.py",
@@ -36,7 +36,7 @@ class TestCommon(unittest.TestCase):
 
     def test_download_file(self):
         self.assertTrue(
-            samgeo.download_file(
+            common.download_file(
                 url="https://github.com/opengeos/leafmap/raw/master/examples/data/world_cities.csv"
             )
         )
@@ -45,18 +45,18 @@ class TestCommon(unittest.TestCase):
         image = "https://github.com/opengeos/data/raw/main/raster/landsat7.tif"
         cog = "tests/data/landsat7_cog.tif"
 
-        samgeo.image_to_cog(image, cog)
+        common.image_to_cog(image, cog)
 
         self.assertTrue(os.path.exists(cog))
 
     def test_vector_to_geojson(self):
         vector = "https://github.com/opengeos/leafmap/raw/master/examples/data/world_cities.geojson"
-        self.assertIsInstance(samgeo.vector_to_geojson(vector), dict)
+        self.assertIsInstance(common.vector_to_geojson(vector), dict)
 
     def test_tms_to_geotiff(self):
         bbox = [-95.3704, 29.6762, -95.368, 29.6775]
         image = "satellite.tif"
-        samgeo.tms_to_geotiff(
+        common.tms_to_geotiff(
             output=image, bbox=bbox, zoom=20, source="Satellite", overwrite=True
         )
         self.assertTrue(os.path.exists(image))

--- a/tests/test_samgeo.py
+++ b/tests/test_samgeo.py
@@ -5,7 +5,7 @@
 import os
 import unittest
 
-from samgeo import samgeo
+from samgeo import common, samgeo
 
 
 class TestSamgeo(unittest.TestCase):
@@ -15,7 +15,7 @@ class TestSamgeo(unittest.TestCase):
         """Set up test fixtures, if any."""
         bbox = [-122.1497, 37.6311, -122.1203, 37.6458]
         image = "satellite.tif"
-        samgeo.tms_to_geotiff(
+        common.tms_to_geotiff(
             output=image, bbox=bbox, zoom=15, source="Satellite", overwrite=True
         )
         self.source = image


### PR DESCRIPTION
Added optional imports, so that the package can be imported in multiple ways without the need to pull all dependencies.

FastSAM is not working because the versions pinned on the package are too old and are not properly loading the model after `torch>2.6.0`, I will take a look at that package. I believe we should pin all required versions in this package as well to prevent these kind of errors in the future.