### PR TITLE
refactor: centralize multi-band RGB preparation for SAM inputs

### DIFF
--- a/samgeo/common.py
+++ b/samgeo/common.py
@@ -1105,12 +1105,122 @@ def write_raster(dst_fp, dst_arr, profile, width, height, transform, crs):
             dst.write(dst_arr[i], i + 1)
 
 
+def _validate_rgb_bands(bands, channel_count):
+    """Validate 1-based band indices and return 0-based channel indices."""
+    if bands is None:
+        return None
+
+    if len(bands) != 3:
+        raise ValueError("bands must contain exactly 3 band indices for RGB.")
+
+    indices = []
+    for band in bands:
+        if band < 1 or band > channel_count:
+            raise ValueError(
+                f"Band index {band} is out of range. "
+                f"Image has {channel_count} bands (1-indexed)."
+            )
+        indices.append(band - 1)
+
+    return indices
+
+
+def _as_uint8(array):
+    """Convert an image array to uint8 while preserving existing uint8 data."""
+    if array.dtype == np.uint8:
+        return array
+
+    if array.dtype == np.bool_:
+        return array.astype(np.uint8) * 255
+
+    array = array.astype(np.float32)
+    array = np.nan_to_num(array, nan=0, posinf=0, neginf=0)
+    min_value = array.min()
+    max_value = array.max()
+
+    if max_value > min_value:
+        array = (array - min_value) / (max_value - min_value) * 255
+    else:
+        array = np.zeros_like(array)
+
+    return array.astype(np.uint8)
+
+
+def prepare_image_for_sam(image, bands=None, channel_axis=-1):
+    """Convert an image-like array to a C-contiguous uint8 RGB array for SAM.
+
+    Args:
+        image (np.ndarray): Input image as a 2D array, HWC array, or CHW array.
+        bands (List[int], optional): Three 1-based channel indices to use as RGB.
+            If not provided, the first three channels are used. Single-band images
+            are repeated and two-band images use bands 1, 2, 1.
+        channel_axis (int, optional): Axis containing channels for 3D arrays.
+            Defaults to -1 for HWC arrays. Use 0 for rasterio-style CHW arrays.
+
+    Returns:
+        np.ndarray: A uint8 RGB image with shape (height, width, 3).
+    """
+    image = np.asarray(image)
+
+    if image.ndim == 2:
+        image = np.repeat(image[:, :, np.newaxis], 3, axis=2)
+        return np.ascontiguousarray(_as_uint8(image))
+
+    if image.ndim != 3:
+        raise ValueError("Input image must be a 2D or 3D array.")
+
+    image = np.moveaxis(image, channel_axis, -1)
+    channel_count = image.shape[-1]
+
+    if bands is not None:
+        indices = _validate_rgb_bands(bands, channel_count)
+        image = image[..., indices]
+    elif channel_count >= 3:
+        image = image[..., :3]
+    elif channel_count == 1:
+        image = np.repeat(image, 3, axis=2)
+    elif channel_count == 2:
+        image = np.concatenate([image, image[..., 0:1]], axis=2)
+    else:
+        raise ValueError("Input image must contain at least one channel.")
+
+    return np.ascontiguousarray(_as_uint8(image))
+
+
+def read_image_for_sam(source, bands=None):
+    """Read an image path as a uint8 RGB array for SAM.
+
+    GeoTIFF files are read with rasterio so images with more than three bands can
+    be reduced to RGB using the first three bands or a user-provided band list.
+    Other image formats are read with OpenCV.
+    """
+    if isinstance(source, str) and source.startswith("http"):
+        source = download_file(source)
+
+    if not os.path.exists(source):
+        raise ValueError(f"Input path {source} does not exist.")
+
+    if source.lower().endswith((".tif", ".tiff")):
+        with rasterio.open(source) as src:
+            if bands is not None:
+                _validate_rgb_bands(bands, src.count)
+                image = np.stack([src.read(b) for b in bands], axis=0)
+            else:
+                image = src.read()
+        return prepare_image_for_sam(image, channel_axis=0)
+
+    if bands is not None:
+        raise ValueError("bands can only be used with multi-band raster files.")
+
+    image = cv2.imread(source)
+    if image is None:
+        raise ValueError(f"Unable to read input image {source}.")
+
+    return cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
+
 def chw_to_hwc(block):
-    # Grab first 3 channels
-    block = block[:3, ...]
-    # CHW to HWC
-    block = np.transpose(block, (1, 2, 0))
-    return block
+    return prepare_image_for_sam(block, channel_axis=0)
 
 
 def hwc_to_hw(block, channel=0):

--- a/samgeo/hq_sam.py
+++ b/samgeo/hq_sam.py
@@ -36,10 +36,12 @@ from samgeo.common import (
     get_pixel_coords,
     get_profile,
     image_to_image,
+    prepare_image_for_sam,
     raster_to_geojson,
     raster_to_gpkg,
     raster_to_shp,
     raster_to_vector,
+    read_image_for_sam,
     sam_map_gui,
     set_transform,
     show_canvas,
@@ -162,6 +164,7 @@ class SamGeo:
             mask_multiplier (int, optional): The mask multiplier for the output mask, which is usually a binary mask [0, 1].
                 You can use this parameter to scale the mask to a larger range, for example [0, 255]. Defaults to 255.
         """
+        image = prepare_image_for_sam(image)
         h, w, _ = image.shape
 
         masks = self.mask_generator.generate(image)
@@ -197,6 +200,7 @@ class SamGeo:
         erosion_kernel=None,
         mask_multiplier=255,
         unique=True,
+        bands=None,
         **kwargs,
     ):
         """Generate masks for the input image.
@@ -213,6 +217,9 @@ class SamGeo:
                 The parameter is ignored if unique is True.
             unique (bool, optional): Whether to assign a unique value to each object. Defaults to True.
                 The unique value increases from 1 to the number of objects. The larger the number, the larger the object area.
+            bands (List[int], optional): Three 1-based band indices to use as RGB
+                when segmenting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
 
         """
 
@@ -231,16 +238,18 @@ class SamGeo:
                     source,
                     output,
                     self,
+                    data_to_rgb=lambda block: prepare_image_for_sam(
+                        block, bands=bands, channel_axis=0
+                    ),
                     foreground=foreground,
                     erosion_kernel=erosion_kernel,
                     mask_multiplier=mask_multiplier,
                     **kwargs,
                 )
 
-            image = cv2.imread(source)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = read_image_for_sam(source, bands=bands)
         elif isinstance(source, np.ndarray):
-            image = source
+            image = prepare_image_for_sam(source, bands=bands)
             source = None
         else:
             raise ValueError("Input source must be either a path or a numpy array.")
@@ -438,12 +447,15 @@ class SamGeo:
                 array = self.annotations
             array_to_image(array, output, self.source)
 
-    def set_image(self, image, image_format="RGB"):
+    def set_image(self, image, image_format="RGB", bands=None):
         """Set the input image as a numpy array.
 
         Args:
             image (np.ndarray): The input image as a numpy array.
             image_format (str, optional): The image format, can be RGB or BGR. Defaults to "RGB".
+            bands (List[int], optional): Three 1-based band indices to use as RGB
+                when setting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
         """
         if isinstance(image, str):
             if image.startswith("http"):
@@ -454,11 +466,11 @@ class SamGeo:
 
             self.source = image
 
-            image = cv2.imread(image)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = read_image_for_sam(image, bands=bands)
             self.image = image
         elif isinstance(image, np.ndarray):
-            pass
+            image = prepare_image_for_sam(image, bands=bands)
+            self.image = image
         else:
             raise ValueError("Input image must be either a path or a numpy array.")
 

--- a/samgeo/samgeo.py
+++ b/samgeo/samgeo.py
@@ -24,10 +24,12 @@ from samgeo.common import (
     get_pixel_coords,
     get_profile,
     image_to_image,
+    prepare_image_for_sam,
     raster_to_geojson,
     raster_to_gpkg,
     raster_to_shp,
     raster_to_vector,
+    read_image_for_sam,
     sam_map_gui,
     set_transform,
     show_canvas,
@@ -149,6 +151,7 @@ class SamGeo:
             mask_multiplier (int, optional): The mask multiplier for the output mask, which is usually a binary mask [0, 1].
                 You can use this parameter to scale the mask to a larger range, for example [0, 255]. Defaults to 255.
         """
+        image = prepare_image_for_sam(image)
         h, w, _ = image.shape
 
         masks = self.mask_generator.generate(image)
@@ -189,6 +192,7 @@ class SamGeo:
         unique=True,
         min_size=0,
         max_size=None,
+        bands=None,
         **kwargs,
     ):
         """Generate masks for the input image.
@@ -213,6 +217,9 @@ class SamGeo:
                 The unique value increases from 1 to the number of objects. The larger the number, the larger the object area.
             min_size (int, optional): The minimum size of the objects. Defaults to 0.
             max_size (int, optional): The maximum size of the objects. Defaults to None.
+            bands (List[int], optional): Three 1-based band indices to use as RGB
+                when segmenting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
             **kwargs: Other arguments for save_masks().
 
         """
@@ -232,6 +239,9 @@ class SamGeo:
                     source,
                     output,
                     self,
+                    data_to_rgb=lambda block: prepare_image_for_sam(
+                        block, bands=bands, channel_axis=0
+                    ),
                     foreground=foreground,
                     sample_size=batch_sample_size,
                     sample_nodata_threshold=batch_nodata_threshold,
@@ -241,10 +251,9 @@ class SamGeo:
                     **kwargs,
                 )
 
-            image = cv2.imread(source)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = read_image_for_sam(source, bands=bands)
         elif isinstance(source, np.ndarray):
-            image = source
+            image = prepare_image_for_sam(source, bands=bands)
             source = None
         else:
             raise ValueError("Input source must be either a path or a numpy array.")
@@ -472,12 +481,15 @@ class SamGeo:
                 array = self.annotations
             array_to_image(array, output, self.source, **kwargs)
 
-    def set_image(self, image, image_format="RGB"):
+    def set_image(self, image, image_format="RGB", bands=None):
         """Set the input image as a numpy array.
 
         Args:
             image (np.ndarray): The input image as a numpy array.
             image_format (str, optional): The image format, can be RGB or BGR. Defaults to "RGB".
+            bands (List[int], optional): Three 1-based band indices to use as RGB
+                when setting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
         """
         if isinstance(image, str):
             if image.startswith("http"):
@@ -488,11 +500,11 @@ class SamGeo:
 
             self.source = image
 
-            image = cv2.imread(image)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = read_image_for_sam(image, bands=bands)
             self.image = image
         elif isinstance(image, np.ndarray):
-            pass
+            image = prepare_image_for_sam(image, bands=bands)
+            self.image = image
         else:
             raise ValueError("Input image must be either a path or a numpy array.")
 

--- a/samgeo/samgeo2.py
+++ b/samgeo/samgeo2.py
@@ -204,6 +204,7 @@ class SamGeo2:
         unique: bool = True,
         min_size: int = 0,
         max_size: int = None,
+        bands: Optional[List[int]] = None,
         **kwargs: Any,
     ) -> List[Dict[str, Any]]:
         """
@@ -229,6 +230,9 @@ class SamGeo2:
                 larger the number, the larger the object area.
             min_size (int): The minimum size of the object. Defaults to 0.
             max_size (int): The maximum size of the object. Defaults to None.
+            bands (Optional[List[int]]): Three 1-based band indices to use as RGB
+                when segmenting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
             **kwargs (Any): Additional keyword arguments.
 
         Returns:
@@ -242,10 +246,9 @@ class SamGeo2:
             if not os.path.exists(source):
                 raise ValueError(f"Input path {source} does not exist.")
 
-            image = cv2.imread(source)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = common.read_image_for_sam(source, bands=bands)
         elif isinstance(source, np.ndarray):
-            image = source
+            image = common.prepare_image_for_sam(source, bands=bands)
             source = None
         else:
             raise ValueError("Input source must be either a path or a numpy array.")
@@ -487,12 +490,16 @@ class SamGeo2:
     def set_image(
         self,
         image: Union[str, np.ndarray, Image],
+        bands: Optional[List[int]] = None,
     ) -> None:
         """Set the input image as a numpy array.
 
         Args:
             image (Union[str, np.ndarray, Image]): The input image as a path,
                 a numpy array, or an Image.
+            bands (Optional[List[int]]): Three 1-based band indices to use as RGB
+                when setting multi-band rasters or arrays. If None, the first
+                three bands are used. Defaults to None.
         """
         if isinstance(image, str):
             if image.startswith("http"):
@@ -503,11 +510,14 @@ class SamGeo2:
 
             self.source = image
 
-            image = cv2.imread(image)
-            image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = common.read_image_for_sam(image, bands=bands)
             self.image = image
-        elif isinstance(image, np.ndarray) or isinstance(image, Image):
-            pass
+        elif isinstance(image, Image):
+            image = common.prepare_image_for_sam(np.array(image), bands=bands)
+            self.image = image
+        elif isinstance(image, np.ndarray):
+            image = common.prepare_image_for_sam(image, bands=bands)
+            self.image = image
         else:
             raise ValueError("Input image must be either a path or a numpy array.")
 
@@ -517,12 +527,16 @@ class SamGeo2:
     def set_image_batch(
         self,
         image_list: List[Union[np.ndarray, str, Image]],
+        bands: Optional[List[int]] = None,
     ) -> None:
         """Set a batch of images for prediction.
 
         Args:
             image_list (List[Union[np.ndarray, str, Image]]): A list of images,
             which can be numpy arrays, file paths, or PIL images.
+            bands (Optional[List[int]]): Three 1-based band indices to use as RGB
+                for each multi-band raster or array. If None, the first three
+                bands are used. Defaults to None.
 
         Raises:
             ValueError: If an input image path does not exist or if the input
@@ -537,12 +551,11 @@ class SamGeo2:
                 if not os.path.exists(image):
                     raise ValueError(f"Input path {image} does not exist.")
 
-                image = cv2.imread(image)
-                image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+                image = common.read_image_for_sam(image, bands=bands)
             elif isinstance(image, Image):
-                image = np.array(image)
+                image = common.prepare_image_for_sam(np.array(image), bands=bands)
             elif isinstance(image, np.ndarray):
-                pass
+                image = common.prepare_image_for_sam(image, bands=bands)
             else:
                 raise ValueError("Input image must be either a path or a numpy array.")
 

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -289,55 +289,13 @@ class SamGeo3:
 
             self.source = image
 
-            # Check if image is a GeoTIFF and handle band selection
-            if image.lower().endswith((".tif", ".tiff")):
-                import rasterio
-
-                with rasterio.open(image) as src:
-                    if bands is not None:
-                        # Validate band indices (1-based)
-                        if len(bands) != 3:
-                            raise ValueError(
-                                "bands must contain exactly 3 band indices for RGB."
-                            )
-                        for band in bands:
-                            if band < 1 or band > src.count:
-                                raise ValueError(
-                                    f"Band index {band} is out of range. "
-                                    f"Image has {src.count} bands (1-indexed)."
-                                )
-                        # Read specified bands (rasterio uses 1-based indexing)
-                        array = np.stack([src.read(b) for b in bands], axis=0)
-                    else:
-                        # Read all bands
-                        array = src.read()
-                        # If more than 3 bands, use first 3
-                        if array.shape[0] >= 3:
-                            array = array[:3, :, :]
-                        elif array.shape[0] == 1:
-                            array = np.repeat(array, 3, axis=0)
-                        elif array.shape[0] == 2:
-                            # Repeat the first band to make 3 bands: [band1, band2, band1]
-                            array = np.concatenate([array, array[0:1, :, :]], axis=0)
-                    # Transpose from (bands, height, width) to (height, width, bands)
-                    array = np.transpose(array, (1, 2, 0))
-
-                    # Normalize to 8-bit (0-255) range
-                    array = array.astype(np.float32)
-                    array -= array.min()
-                    if array.max() > 0:
-                        array /= array.max()
-                    array *= 255
-                    image = array.astype(np.uint8)
-            else:
-                image = cv2.imread(image)
-                image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+            image = common.read_image_for_sam(image, bands=bands)
             self.image = image
         elif isinstance(image, np.ndarray):
-            self.image = image
+            self.image = common.prepare_image_for_sam(image, bands=bands)
             self.source = None
         elif isinstance(image, Image.Image):
-            self.image = np.array(image)
+            self.image = common.prepare_image_for_sam(np.array(image), bands=bands)
             self.source = None
         else:
             raise ValueError(
@@ -377,6 +335,7 @@ class SamGeo3:
         self,
         images: List[Union[str, np.ndarray, Image.Image]],
         state: Optional[Dict] = None,
+        bands: Optional[List[int]] = None,
     ) -> None:
         """Set multiple images for batch processing.
 
@@ -387,6 +346,9 @@ class SamGeo3:
                 Each image can be a file path, a numpy array, or a PIL Image.
             state (dict, optional): An optional state object to pass to the
                 processor's set_image_batch method.
+            bands (List[int], optional): Three 1-based band indices to use as RGB
+                for each multi-band raster or array. If None, the first three
+                bands are used. Defaults to None.
 
         Example:
             >>> sam = SamGeo3(backend="meta")
@@ -416,20 +378,21 @@ class SamGeo3:
                     raise ValueError(f"Input path {image} does not exist.")
 
                 sources.append(image)
-                img = cv2.imread(image)
-                img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+                img = common.read_image_for_sam(image, bands=bands)
                 numpy_images.append(img)
                 pil_images.append(Image.fromarray(img))
 
             elif isinstance(image, np.ndarray):
                 sources.append(None)
-                numpy_images.append(image)
-                pil_images.append(Image.fromarray(image))
+                img = common.prepare_image_for_sam(image, bands=bands)
+                numpy_images.append(img)
+                pil_images.append(Image.fromarray(img))
 
             elif isinstance(image, Image.Image):
                 sources.append(None)
-                numpy_images.append(np.array(image))
-                pil_images.append(image)
+                img = common.prepare_image_for_sam(np.array(image), bands=bands)
+                numpy_images.append(img)
+                pil_images.append(Image.fromarray(img))
 
             else:
                 raise ValueError(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,7 +3,11 @@
 """Tests for `samgeo` package."""
 
 import os
+import tempfile
 import unittest
+
+import numpy as np
+import rasterio
 
 from samgeo import common
 
@@ -25,6 +29,54 @@ class TestCommon(unittest.TestCase):
 
     def test_temp_file_path(self):
         self.assertFalse(os.path.exists(common.temp_file_path(extension=".tif")))
+
+    def test_prepare_image_for_sam_multichannel_array(self):
+        image = np.zeros((4, 5, 5), dtype=np.uint8)
+        image[..., 0] = 10
+        image[..., 1] = 20
+        image[..., 2] = 30
+        image[..., 3] = 40
+        image[..., 4] = 50
+
+        rgb = common.prepare_image_for_sam(image)
+        self.assertEqual(rgb.shape, (4, 5, 3))
+        np.testing.assert_array_equal(rgb[..., 0], image[..., 0])
+        np.testing.assert_array_equal(rgb[..., 1], image[..., 1])
+        np.testing.assert_array_equal(rgb[..., 2], image[..., 2])
+
+        false_color = common.prepare_image_for_sam(image, bands=[5, 3, 1])
+        np.testing.assert_array_equal(false_color[..., 0], image[..., 4])
+        np.testing.assert_array_equal(false_color[..., 1], image[..., 2])
+        np.testing.assert_array_equal(false_color[..., 2], image[..., 0])
+
+    def test_read_image_for_sam_multiband_geotiff(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            image = os.path.join(tmpdir, "multiband.tif")
+            data = np.zeros((5, 4, 6), dtype=np.uint8)
+            for band in range(data.shape[0]):
+                data[band] = (band + 1) * 10
+
+            with rasterio.open(
+                image,
+                "w",
+                driver="GTiff",
+                height=data.shape[1],
+                width=data.shape[2],
+                count=data.shape[0],
+                dtype=data.dtype,
+            ) as dst:
+                dst.write(data)
+
+            rgb = common.read_image_for_sam(image)
+            self.assertEqual(rgb.shape, (4, 6, 3))
+            np.testing.assert_array_equal(rgb[..., 0], data[0])
+            np.testing.assert_array_equal(rgb[..., 1], data[1])
+            np.testing.assert_array_equal(rgb[..., 2], data[2])
+
+            false_color = common.read_image_for_sam(image, bands=[5, 3, 1])
+            np.testing.assert_array_equal(false_color[..., 0], data[4])
+            np.testing.assert_array_equal(false_color[..., 1], data[2])
+            np.testing.assert_array_equal(false_color[..., 2], data[0])
 
     def test_github_raw_url(self):
         self.assertEqual(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -8,6 +8,7 @@ import unittest
 
 import numpy as np
 import rasterio
+from rasterio.transform import from_origin
 
 from samgeo import common
 
@@ -64,6 +65,8 @@ class TestCommon(unittest.TestCase):
                 width=data.shape[2],
                 count=data.shape[0],
                 dtype=data.dtype,
+                crs="EPSG:4326",
+                transform=from_origin(-180, 90, 1, 1),
             ) as dst:
                 dst.write(data)
 


### PR DESCRIPTION
## Summary
- Add `prepare_image_for_sam` and `read_image_for_sam` helpers in `samgeo.common` to handle multi-band rasters, channel-axis layout, and uint8 normalization in one place.
- Route `SamGeo`, `SamGeo2`, `SamGeo3`, and HQ-SAM through the shared helpers and expose a `bands` argument on `set_image`, `set_image_batch`, and `generate` so users can pick the RGB bands explicitly.
- Drop the duplicated GeoTIFF/normalization branch in `SamGeo3.set_image` and the ad-hoc `cv2.imread` paths in the other backends.

## Test plan
- [x] `pre-commit run --all-files`
- [ ] `pytest tests/test_common.py`