### PR TITLE
Add SAM 3.1 model support

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -96,7 +96,7 @@ Runs automatic mask generation on an uploaded image. Supports SAM, SAM2, and SAM
 |-----------|------|---------|-------------|
 | `file` | file | required | Image file (TIFF, PNG, JPEG) |
 | `model_version` | string | `sam2` | One of `sam`, `sam2`, `sam3` |
-| `model_id` | string | auto | Model identifier (e.g., `sam2-hiera-large`) |
+| `model_id` | string | auto | Model identifier (e.g., `sam2-hiera-large`, `facebook/sam3.1`) |
 | `output_format` | string | `geojson` | One of `geojson`, `geotiff`, `png`, `json`, `detections` |
 | `foreground` | bool | `true` | Extract foreground objects only |
 | `unique` | bool | `true` | Assign unique ID to each object |
@@ -131,7 +131,7 @@ For SAM3 with bounding box prompts, the model finds **all similar objects** in t
 |-----------|------|---------|-------------|
 | `file` | file | required | Image file (TIFF, PNG, JPEG) |
 | `model_version` | string | `sam3` | One of `sam`, `sam2`, `sam3` |
-| `model_id` | string | auto | Model identifier |
+| `model_id` | string | auto | Model identifier (e.g., `facebook/sam3.1`) |
 | `output_format` | string | `geojson` | One of `geojson`, `geotiff`, `png`, `json`, `detections` |
 | `point_coords` | string | none | JSON array of `[[x, y], ...]` |
 | `point_labels` | string | none | JSON array of `[1, 0, ...]` (1=foreground, 0=background) |
@@ -222,8 +222,8 @@ Runs text-prompt segmentation using SAM3.
 |-----------|------|---------|-------------|
 | `file` | file | required | Image file (TIFF, PNG, JPEG) |
 | `prompt` | string | required | Text description (e.g., `building`, `tree`) |
-| `model_id` | string | auto | SAM3 model identifier |
-| `backend` | string | `meta` | One of `meta`, `transformers` |
+| `model_id` | string | auto | SAM3 model identifier (`facebook/sam3` or `facebook/sam3.1`) |
+| `backend` | string | `meta` | One of `meta`, `transformers`; SAM 3.1 uses `meta` |
 | `output_format` | string | `geojson` | One of `geojson`, `geotiff`, `png`, `json`, `detections` |
 | `confidence_threshold` | float | `0.5` | Detection confidence threshold |
 | `min_size` | int | `0` | Minimum mask size in pixels |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,6 +165,10 @@ For SAM 3.1:
 pixi run hf download facebook/sam3.1
 ```
 
+When `segment-geospatial` is installed with a released `sam3` package whose
+checkpoint helper only downloads `facebook/sam3`, SAM 3.1 still downloads
+`facebook/sam3.1` directly through Hugging Face Hub.
+
 **Important Note**: SAM 3 and SAM 3.1 currently require an NVIDIA GPU with CUDA support. You won't be able to use them if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
 
 ---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,9 +145,9 @@ If CUDA is `False`, check:
 
 ---
 
-### 6) Request access to SAM 3 (Optional)
+### 6) Request access to SAM 3 and SAM 3.1 (Optional)
 
-To use SAM 3, you will need to request access by filling out this form on Hugging Face at <https://huggingface.co/facebook/sam3>. Once your request has been approved, run the following command in the terminal to authenticate:
+To use SAM 3, you will need to request access by filling out this form on Hugging Face at <https://huggingface.co/facebook/sam3>. To use SAM 3.1, request access at <https://huggingface.co/facebook/sam3.1>. Once your request has been approved, run the following command in the terminal to authenticate:
 
 ```bash
 pixi run hf auth login
@@ -159,7 +159,13 @@ After authentication, you can download the SAM 3 model from Hugging Face:
 pixi run hf download facebook/sam3
 ```
 
-**Important Note**: SAM 3 currently requires an NVIDIA GPU with CUDA support. You won't be able to use SAM 3 if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
+For SAM 3.1:
+
+```bash
+pixi run hf download facebook/sam3.1
+```
+
+**Important Note**: SAM 3 and SAM 3.1 currently require an NVIDIA GPU with CUDA support. You won't be able to use them if you have a CPU only system ([source](https://github.com/facebookresearch/sam3/issues/164)). You will get an error message like this: `Failed to load model: Torch not compiled with CUDA enabled`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ samgeo2 = [
 ]
 samgeo3 = [
     "segment_geospatial[core]",
-    "sam3",
+    "sam3>=0.1.4",
     "scikit-learn",
     "scikit-image",
     "transformers",

--- a/samgeo/api.py
+++ b/samgeo/api.py
@@ -78,6 +78,11 @@ _model_cache_lock = threading.Lock()
 # When the same image is sent again, we skip the expensive set_image() call.
 _image_hash_cache: dict = {}
 
+# Backward-compatible aliases for code that imported these private constants.
+_DEFAULT_MODEL_IDS = DEFAULT_MODEL_IDS
+_AVAILABLE_MODELS = AVAILABLE_MODELS
+_EXTRAS_MAP = EXTRAS_MAP
+
 
 def _freeze_kwargs(kwargs: dict):
     """Return a hashable, order-independent representation of model kwargs.

--- a/samgeo/api.py
+++ b/samgeo/api.py
@@ -35,6 +35,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 
 from samgeo import __version__
+from samgeo.model_registry import AVAILABLE_MODELS, DEFAULT_MODEL_IDS, EXTRAS_MAP
 
 logger = logging.getLogger("uvicorn.error")
 
@@ -76,31 +77,6 @@ _model_cache_lock = threading.Lock()
 # Image encoding cache: maps model cache key -> hash of last encoded image.
 # When the same image is sent again, we skip the expensive set_image() call.
 _image_hash_cache: dict = {}
-
-# Default model IDs per version
-_DEFAULT_MODEL_IDS = {
-    "sam": "vit_h",
-    "sam2": "sam2-hiera-large",
-    "sam3": "facebook/sam3",
-}
-
-_AVAILABLE_MODELS = {
-    "sam": ["vit_h", "vit_l", "vit_b"],
-    "sam2": [
-        "sam2-hiera-tiny",
-        "sam2-hiera-small",
-        "sam2-hiera-base-plus",
-        "sam2-hiera-large",
-    ],
-    "sam3": ["facebook/sam3"],
-}
-
-# Maps model_version to the correct pip extra name
-_EXTRAS_MAP = {
-    "sam": "samgeo",
-    "sam2": "samgeo2",
-    "sam3": "samgeo3",
-}
 
 
 def _freeze_kwargs(kwargs: dict):
@@ -147,19 +123,19 @@ def get_model(model_version: str, model_id: Optional[str] = None, **kwargs):
         HTTPException: If model_version or model_id is invalid, or
             dependencies are missing.
     """
-    if model_version not in _DEFAULT_MODEL_IDS:
+    if model_version not in DEFAULT_MODEL_IDS:
         raise HTTPException(
             status_code=400,
             detail=(
                 f"Invalid model_version '{model_version}'. "
-                f"Must be one of: {list(_DEFAULT_MODEL_IDS.keys())}"
+                f"Must be one of: {list(DEFAULT_MODEL_IDS.keys())}"
             ),
         )
 
     if not model_id:
-        model_id = _DEFAULT_MODEL_IDS[model_version]
+        model_id = DEFAULT_MODEL_IDS[model_version]
 
-    valid_ids = _AVAILABLE_MODELS[model_version]
+    valid_ids = AVAILABLE_MODELS[model_version]
     if model_id not in valid_ids:
         raise HTTPException(
             status_code=400,
@@ -185,7 +161,7 @@ def get_model(model_version: str, model_id: Optional[str] = None, **kwargs):
             return model, lock, key
 
         logger.info("Loading model %s", key)
-        extra = _EXTRAS_MAP.get(model_version, model_version)
+        extra = EXTRAS_MAP.get(model_version, model_version)
         try:
             if model_version == "sam":
                 from samgeo.samgeo import SamGeo
@@ -199,7 +175,7 @@ def get_model(model_version: str, model_id: Optional[str] = None, **kwargs):
                 from samgeo.samgeo3 import SamGeo3
 
                 kwargs.setdefault("enable_inst_interactivity", True)
-                model = SamGeo3(**kwargs)
+                model = SamGeo3(model_id=model_id, **kwargs)
         except ImportError as e:
             raise HTTPException(
                 status_code=503,
@@ -570,7 +546,7 @@ def health():
 def list_models():
     """List available and currently loaded models."""
     loaded = [list(key) for key in _model_cache]
-    return {"models": _AVAILABLE_MODELS, "loaded": loaded}
+    return {"models": AVAILABLE_MODELS, "loaded": loaded}
 
 
 @app.delete("/models")

--- a/samgeo/api.py
+++ b/samgeo/api.py
@@ -176,6 +176,8 @@ def get_model(model_version: str, model_id: Optional[str] = None, **kwargs):
 
                 kwargs.setdefault("enable_inst_interactivity", True)
                 model = SamGeo3(model_id=model_id, **kwargs)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
         except ImportError as e:
             raise HTTPException(
                 status_code=503,

--- a/samgeo/api.py
+++ b/samgeo/api.py
@@ -182,7 +182,14 @@ def get_model(model_version: str, model_id: Optional[str] = None, **kwargs):
                 kwargs.setdefault("enable_inst_interactivity", True)
                 model = SamGeo3(model_id=model_id, **kwargs)
         except ValueError as e:
-            raise HTTPException(status_code=400, detail=str(e))
+            msg = str(e)
+            is_user_config_error = model_version == "sam3" and (
+                msg.startswith("Invalid backend")
+                or "only supported with backend='meta'" in msg
+            )
+            if is_user_config_error:
+                raise HTTPException(status_code=400, detail=msg) from e
+            raise
         except ImportError as e:
             raise HTTPException(
                 status_code=503,

--- a/samgeo/model_registry.py
+++ b/samgeo/model_registry.py
@@ -1,0 +1,26 @@
+"""Shared model identifiers used across samgeo entry points."""
+
+SAM3_MODEL_IDS = ("facebook/sam3", "facebook/sam3.1")
+
+DEFAULT_MODEL_IDS = {
+    "sam": "vit_h",
+    "sam2": "sam2-hiera-large",
+    "sam3": "facebook/sam3",
+}
+
+AVAILABLE_MODELS = {
+    "sam": ["vit_h", "vit_l", "vit_b"],
+    "sam2": [
+        "sam2-hiera-tiny",
+        "sam2-hiera-small",
+        "sam2-hiera-base-plus",
+        "sam2-hiera-large",
+    ],
+    "sam3": list(SAM3_MODEL_IDS),
+}
+
+EXTRAS_MAP = {
+    "sam": "samgeo",
+    "sam2": "samgeo2",
+    "sam3": "samgeo3",
+}

--- a/samgeo/model_registry.py
+++ b/samgeo/model_registry.py
@@ -1,11 +1,13 @@
 """Shared model identifiers used across samgeo entry points."""
 
-SAM3_MODEL_IDS = ("facebook/sam3", "facebook/sam3.1")
+SAM3_MODEL_ID = "facebook/sam3"
+SAM31_MODEL_ID = "facebook/sam3.1"
+SAM3_MODEL_IDS = (SAM3_MODEL_ID, SAM31_MODEL_ID)
 
 DEFAULT_MODEL_IDS = {
     "sam": "vit_h",
     "sam2": "sam2-hiera-large",
-    "sam3": "facebook/sam3",
+    "sam3": SAM3_MODEL_ID,
 }
 
 AVAILABLE_MODELS = {

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -15,6 +15,12 @@ from tqdm import tqdm
 SAM3_META_IMPORT_ERROR = None
 try:
     from sam3.model_builder import build_sam3_image_model, build_sam3_video_predictor
+
+    try:
+        from sam3.model_builder import download_ckpt_from_hf
+    except ImportError:
+        download_ckpt_from_hf = None
+
     from sam3.model.sam3_image_processor import Sam3Processor as MetaSam3Processor
     from sam3.visualization_utils import load_frame
 
@@ -43,6 +49,7 @@ except ImportError as e:
     print(f"To use SamGeo 3, install it as:\n\tpip install segment-geospatial[samgeo3]")
 
 from samgeo import common
+from samgeo.model_registry import DEFAULT_MODEL_IDS, SAM3_MODEL_IDS
 from .common import show_image
 
 try:
@@ -59,7 +66,7 @@ class SamGeo3:
     def __init__(
         self,
         backend="meta",
-        model_id="facebook/sam3",
+        model_id=DEFAULT_MODEL_IDS["sam3"],
         bpe_path=None,
         device=None,
         eval_mode=True,
@@ -78,8 +85,10 @@ class SamGeo3:
 
         Args:
             backend (str): Backend to use ('meta' or 'transformers'). Default is 'meta'.
-            model_id (str): Model ID for Transformers backend (e.g., 'facebook/sam3').
-                Only used when backend='transformers'.
+            model_id (str): Model ID to use. Supported values are
+                'facebook/sam3' and 'facebook/sam3.1'. The Meta backend uses
+                this to select the Hugging Face checkpoint when
+                load_from_HF=True and checkpoint_path is not provided.
             bpe_path (str, optional): Path to the BPE tokenizer vocabulary (Meta backend only).
             device (str, optional): Device to load the model on ('cuda' or 'cpu').
             eval_mode (bool, optional): Whether to set the model to evaluation mode (Meta backend only).
@@ -112,9 +121,22 @@ class SamGeo3:
             ... )
         """
 
+        if model_id not in SAM3_MODEL_IDS:
+            raise ValueError(
+                f"Invalid SAM3 model_id '{model_id}'. "
+                f"Choose one of: {list(SAM3_MODEL_IDS)}."
+            )
+
         if backend not in ["meta", "transformers"]:
             raise ValueError(
                 f"Invalid backend '{backend}'. Choose 'meta' or 'transformers'."
+            )
+
+        if backend == "transformers" and model_id == "facebook/sam3.1":
+            raise ValueError(
+                "facebook/sam3.1 is a checkpoint repository and is only "
+                "supported with backend='meta'. Use model_id='facebook/sam3' "
+                "for the Transformers backend."
             )
 
         if backend == "meta" and not SAM3_META_AVAILABLE:
@@ -152,6 +174,7 @@ class SamGeo3:
         # Initialize backend-specific components
         if backend == "meta":
             self._init_meta_backend(
+                model_id=model_id,
                 bpe_path=bpe_path,
                 device=device,
                 eval_mode=eval_mode,
@@ -191,6 +214,7 @@ class SamGeo3:
 
     def _init_meta_backend(
         self,
+        model_id,
         bpe_path,
         device,
         eval_mode,
@@ -221,6 +245,20 @@ class SamGeo3:
         if checkpoint_path is not None:
             if not os.path.exists(checkpoint_path):
                 raise ValueError(f"Checkpoint path {checkpoint_path} does not exist.")
+            load_from_HF = False
+
+        if (
+            load_from_HF
+            and checkpoint_path is None
+            and model_id == "facebook/sam3.1"
+        ):
+            if download_ckpt_from_hf is None:
+                raise ImportError(
+                    "SAM 3.1 requires a newer sam3 package with "
+                    "download_ckpt_from_hf(version='sam3.1'). "
+                    "Please upgrade segment-geospatial[samgeo3]."
+                )
+            checkpoint_path = download_ckpt_from_hf(version="sam3.1")
             load_from_HF = False
 
         model = build_sam3_image_model(

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -3,6 +3,7 @@ https://github.com/facebookresearch/sam3
 """
 
 import glob
+import inspect
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -50,7 +51,7 @@ except ImportError as e:
     print(f"To use SamGeo 3, install it as:\n\tpip install segment-geospatial[samgeo3]")
 
 from samgeo import common
-from samgeo.model_registry import DEFAULT_MODEL_IDS
+from samgeo.model_registry import DEFAULT_MODEL_IDS, SAM31_MODEL_ID
 from .common import show_image
 
 try:
@@ -59,6 +60,30 @@ try:
     hf_logging.set_verbosity_error()  # silence HF load reports
 except ImportError:
     pass
+
+
+SAM31_CKPT_NAME = "sam3.1_multiplex.pt"
+SAM31_CONFIG_NAME = "config.json"
+
+
+def _download_sam31_checkpoint():
+    """Download the SAM 3.1 checkpoint with released and source sam3 builds."""
+    if download_ckpt_from_hf is not None:
+        signature = inspect.signature(download_ckpt_from_hf)
+        if "version" in signature.parameters:
+            return download_ckpt_from_hf(version="sam3.1")
+
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as e:
+        raise ImportError(
+            "SAM 3.1 requires either a sam3 package whose "
+            "download_ckpt_from_hf supports version='sam3.1' or "
+            "huggingface_hub to download facebook/sam3.1 directly."
+        ) from e
+
+    _ = hf_hub_download(repo_id=SAM31_MODEL_ID, filename=SAM31_CONFIG_NAME)
+    return hf_hub_download(repo_id=SAM31_MODEL_ID, filename=SAM31_CKPT_NAME)
 
 
 class SamGeo3:
@@ -127,7 +152,7 @@ class SamGeo3:
                 f"Invalid backend '{backend}'. Choose 'meta' or 'transformers'."
             )
 
-        if backend == "transformers" and model_id == "facebook/sam3.1":
+        if backend == "transformers" and model_id == SAM31_MODEL_ID:
             raise ValueError(
                 "facebook/sam3.1 is a checkpoint repository and is only "
                 "supported with backend='meta'. Use model_id='facebook/sam3' "
@@ -245,15 +270,9 @@ class SamGeo3:
         if (
             load_from_HF
             and checkpoint_path is None
-            and model_id == "facebook/sam3.1"
+            and model_id == SAM31_MODEL_ID
         ):
-            if download_ckpt_from_hf is None:
-                raise ImportError(
-                    "SAM 3.1 requires a newer sam3 package with "
-                    "download_ckpt_from_hf(version='sam3.1'). "
-                    "Please upgrade segment-geospatial[samgeo3]."
-                )
-            checkpoint_path = download_ckpt_from_hf(version="sam3.1")
+            checkpoint_path = _download_sam31_checkpoint()
             load_from_HF = False
 
         model = build_sam3_image_model(

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 
 
 SAM3_META_IMPORT_ERROR = None
+download_ckpt_from_hf = None
 try:
     from sam3.model_builder import build_sam3_image_model, build_sam3_video_predictor
 

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -49,7 +49,7 @@ except ImportError as e:
     print(f"To use SamGeo 3, install it as:\n\tpip install segment-geospatial[samgeo3]")
 
 from samgeo import common
-from samgeo.model_registry import DEFAULT_MODEL_IDS, SAM3_MODEL_IDS
+from samgeo.model_registry import DEFAULT_MODEL_IDS
 from .common import show_image
 
 try:
@@ -85,10 +85,10 @@ class SamGeo3:
 
         Args:
             backend (str): Backend to use ('meta' or 'transformers'). Default is 'meta'.
-            model_id (str): Model ID to use. Supported values are
+            model_id (str): Model ID to use. Official values include
                 'facebook/sam3' and 'facebook/sam3.1'. The Meta backend uses
-                this to select the Hugging Face checkpoint when
-                load_from_HF=True and checkpoint_path is not provided.
+                'facebook/sam3.1' to select the SAM 3.1 Hugging Face checkpoint
+                when load_from_HF=True and checkpoint_path is not provided.
             bpe_path (str, optional): Path to the BPE tokenizer vocabulary (Meta backend only).
             device (str, optional): Device to load the model on ('cuda' or 'cpu').
             eval_mode (bool, optional): Whether to set the model to evaluation mode (Meta backend only).
@@ -120,12 +120,6 @@ class SamGeo3:
             ...     point_labels=np.array([1]),
             ... )
         """
-
-        if model_id not in SAM3_MODEL_IDS:
-            raise ValueError(
-                f"Invalid SAM3 model_id '{model_id}'. "
-                f"Choose one of: {list(SAM3_MODEL_IDS)}."
-            )
 
         if backend not in ["meta", "transformers"]:
             raise ValueError(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -59,6 +59,15 @@ def test_list_models():
     assert data["loaded"] == []
 
 
+def test_private_model_constant_aliases_remain_available():
+    """Legacy private constants still point to the shared registry values."""
+    import samgeo.api as api
+
+    assert api._DEFAULT_MODEL_IDS is api.DEFAULT_MODEL_IDS
+    assert api._AVAILABLE_MODELS is api.AVAILABLE_MODELS
+    assert api._EXTRAS_MAP is api.EXTRAS_MAP
+
+
 def test_clear_models():
     """Test clearing the model cache."""
     response = client.delete("/models")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -61,7 +61,7 @@ def test_list_models():
 
 def test_private_model_constant_aliases_remain_available():
     """Legacy private constants still point to the shared registry values."""
-    import samgeo.api as api
+    from samgeo import api
 
     assert api._DEFAULT_MODEL_IDS is api.DEFAULT_MODEL_IDS
     assert api._AVAILABLE_MODELS is api.AVAILABLE_MODELS
@@ -200,7 +200,7 @@ def test_get_model_caches_automatic_and_predict_separately():
     ``'SamGeo2' object has no attribute 'predictor'``. The cache key now
     includes the ``automatic`` flag so the two are distinct instances.
     """
-    import samgeo.api as api
+    from samgeo import api
 
     with patch("samgeo.samgeo2.SamGeo2") as mock_cls:
         mock_cls.side_effect = lambda **kw: MagicMock()
@@ -227,7 +227,7 @@ def test_get_model_caches_distinct_configs_separately():
     request with a different ``points_per_side``) silently reused the first,
     differently-configured instance. The key now folds in the kwargs.
     """
-    import samgeo.api as api
+    from samgeo import api
 
     # SAM3: two text requests differing only by confidence_threshold.
     with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
@@ -250,7 +250,7 @@ def test_get_model_caches_distinct_configs_separately():
 
 def test_get_model_accepts_sam31_model_id():
     """SAM 3.1 is a supported SAM3 model id and keeps its own cache key."""
-    import samgeo.api as api
+    from samgeo import api
 
     with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
         mock_sam3.side_effect = lambda **kw: MagicMock()
@@ -273,7 +273,7 @@ def test_get_model_accepts_sam31_model_id():
 
 def test_get_model_returns_400_for_invalid_constructor_config():
     """Invalid model/backend config should be reported as a user error."""
-    import samgeo.api as api
+    from samgeo import api
 
     with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
         mock_sam3.side_effect = ValueError(
@@ -288,7 +288,7 @@ def test_get_model_returns_400_for_invalid_constructor_config():
 
 def test_get_model_does_not_hide_unexpected_constructor_value_errors():
     """Unexpected constructor ValueErrors should not be reported as bad input."""
-    import samgeo.api as api
+    from samgeo import api
 
     with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
         mock_sam3.side_effect = ValueError("unexpected runtime failure")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,7 @@ def test_list_models():
     assert "sam" in data["models"]
     assert "sam2" in data["models"]
     assert "sam3" in data["models"]
+    assert "facebook/sam3.1" in data["models"]["sam3"]
     assert data["loaded"] == []
 
 
@@ -236,6 +237,29 @@ def test_get_model_caches_distinct_configs_separately():
         s_b, _, k_b = api.get_model("sam2", "sam2-hiera-tiny", points_per_side=32)
     assert k_a != k_b
     assert s_a is not s_b
+
+
+def test_get_model_accepts_sam31_model_id():
+    """SAM 3.1 is a supported SAM3 model id and keeps its own cache key."""
+    import samgeo.api as api
+
+    with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
+        mock_sam3.side_effect = lambda **kw: MagicMock()
+        sam3_model, _, sam3_key = api.get_model("sam3", "facebook/sam3")
+        sam31_model, _, sam31_key = api.get_model("sam3", "facebook/sam3.1")
+        sam31_again, _, _ = api.get_model("sam3", "facebook/sam3.1")
+
+    assert sam3_key != sam31_key
+    assert sam3_model is not sam31_model
+    assert sam31_again is sam31_model
+    mock_sam3.assert_any_call(
+        model_id="facebook/sam3",
+        enable_inst_interactivity=True,
+    )
+    mock_sam3.assert_any_call(
+        model_id="facebook/sam3.1",
+        enable_inst_interactivity=True,
+    )
 
 
 def test_freeze_kwargs_is_order_independent():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -276,12 +276,24 @@ def test_get_model_returns_400_for_invalid_constructor_config():
     import samgeo.api as api
 
     with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
-        mock_sam3.side_effect = ValueError("bad config")
+        mock_sam3.side_effect = ValueError(
+            "facebook/sam3.1 is only supported with backend='meta'"
+        )
         with pytest.raises(api.HTTPException) as excinfo:
             api.get_model("sam3", "facebook/sam3.1", backend="transformers")
 
     assert excinfo.value.status_code == 400
-    assert "bad config" in excinfo.value.detail
+    assert "backend='meta'" in excinfo.value.detail
+
+
+def test_get_model_does_not_hide_unexpected_constructor_value_errors():
+    """Unexpected constructor ValueErrors should not be reported as bad input."""
+    import samgeo.api as api
+
+    with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
+        mock_sam3.side_effect = ValueError("unexpected runtime failure")
+        with pytest.raises(ValueError, match="unexpected runtime failure"):
+            api.get_model("sam3", "facebook/sam3.1", backend="meta")
 
 
 def test_freeze_kwargs_is_order_independent():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -262,6 +262,19 @@ def test_get_model_accepts_sam31_model_id():
     )
 
 
+def test_get_model_returns_400_for_invalid_constructor_config():
+    """Invalid model/backend config should be reported as a user error."""
+    import samgeo.api as api
+
+    with patch("samgeo.samgeo3.SamGeo3") as mock_sam3:
+        mock_sam3.side_effect = ValueError("bad config")
+        with pytest.raises(api.HTTPException) as excinfo:
+            api.get_model("sam3", "facebook/sam3.1", backend="transformers")
+
+    assert excinfo.value.status_code == 400
+    assert "bad config" in excinfo.value.detail
+
+
 def test_freeze_kwargs_is_order_independent():
     """_freeze_kwargs yields the same hashable key regardless of arg order."""
     from samgeo.api import _freeze_kwargs

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -21,6 +21,12 @@ def test_default_model_ids_are_available_models():
         assert model_id in model_registry.AVAILABLE_MODELS[model_version]
 
 
+def test_registry_keys_stay_in_sync():
+    """Shared registry sections should describe the same model versions."""
+    assert set(model_registry.DEFAULT_MODEL_IDS) == set(model_registry.AVAILABLE_MODELS)
+    assert set(model_registry.DEFAULT_MODEL_IDS) == set(model_registry.EXTRAS_MAP)
+
+
 def test_sam31_is_registered_as_a_sam3_model():
     """SAM 3.1 is exposed as a SAM3-compatible model id."""
     assert "facebook/sam3" in model_registry.SAM3_MODEL_IDS

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -1,0 +1,31 @@
+"""Tests for shared model registry constants."""
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_model_registry():
+    module_path = Path(__file__).resolve().parents[1] / "samgeo" / "model_registry.py"
+    spec = importlib.util.spec_from_file_location("model_registry", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+model_registry = _load_model_registry()
+
+
+def test_default_model_ids_are_available_models():
+    """Every default model id should be listed as available."""
+    for model_version, model_id in model_registry.DEFAULT_MODEL_IDS.items():
+        assert model_id in model_registry.AVAILABLE_MODELS[model_version]
+
+
+def test_sam31_is_registered_as_a_sam3_model():
+    """SAM 3.1 is exposed as a SAM3-compatible model id."""
+    assert "facebook/sam3" in model_registry.SAM3_MODEL_IDS
+    assert "facebook/sam3.1" in model_registry.SAM3_MODEL_IDS
+    assert (
+        list(model_registry.SAM3_MODEL_IDS)
+        == model_registry.AVAILABLE_MODELS["sam3"]
+    )

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -29,8 +29,10 @@ def test_registry_keys_stay_in_sync():
 
 def test_sam31_is_registered_as_a_sam3_model():
     """SAM 3.1 is exposed as a SAM3-compatible model id."""
-    assert "facebook/sam3" in model_registry.SAM3_MODEL_IDS
-    assert "facebook/sam3.1" in model_registry.SAM3_MODEL_IDS
+    assert model_registry.SAM3_MODEL_ID == "facebook/sam3"
+    assert model_registry.SAM31_MODEL_ID == "facebook/sam3.1"
+    assert model_registry.SAM3_MODEL_ID in model_registry.SAM3_MODEL_IDS
+    assert model_registry.SAM31_MODEL_ID in model_registry.SAM3_MODEL_IDS
     assert (
         list(model_registry.SAM3_MODEL_IDS)
         == model_registry.AVAILABLE_MODELS["sam3"]

--- a/tests/test_samgeo3.py
+++ b/tests/test_samgeo3.py
@@ -57,6 +57,15 @@ def _patch_meta_build(monkeypatch, samgeo3):
     return builder, processor
 
 
+def _patch_hf_hub_download(monkeypatch):
+    hub = types.ModuleType("huggingface_hub")
+    hub.hf_hub_download = Mock(
+        side_effect=lambda repo_id, filename: f"/tmp/{repo_id.replace('/', '-')}/{filename}"
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    return hub.hf_hub_download
+
+
 def _init_meta_backend(samgeo3, **overrides):
     params = {
         "model_id": "facebook/sam3.1",
@@ -119,8 +128,13 @@ def test_sam31_load_from_hf_uses_versioned_checkpoint_download(
     checkpoint_path = tmp_path / "sam3.1_multiplex.pt"
 
     builder, _ = _patch_meta_build(monkeypatch, samgeo3)
-    downloader = Mock(return_value=str(checkpoint_path))
-    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", downloader)
+
+    def download_ckpt_from_hf(*, version):
+        downloader(version=version)
+        return str(checkpoint_path)
+
+    downloader = Mock()
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", download_ckpt_from_hf)
 
     _init_meta_backend(
         samgeo3,
@@ -129,6 +143,43 @@ def test_sam31_load_from_hf_uses_versioned_checkpoint_download(
 
     downloader.assert_called_once_with(version="sam3.1")
     assert builder.call_args.kwargs["checkpoint_path"] == str(checkpoint_path)
+    assert builder.call_args.kwargs["load_from_HF"] is False
+
+
+def test_sam31_old_downloader_signature_uses_hf_hub_fallback(
+    monkeypatch, tmp_path, samgeo3
+):
+    """PyPI sam3 0.1.4 has an old no-arg helper, so fallback to HF directly."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    old_downloader = Mock(return_value="/tmp/facebook-sam3/sam3.pt")
+
+    def download_ckpt_from_hf():
+        return old_downloader()
+
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", download_ckpt_from_hf)
+    hf_hub_download = _patch_hf_hub_download(monkeypatch)
+
+    _init_meta_backend(
+        samgeo3,
+        bpe_path=str(bpe_path),
+    )
+
+    old_downloader.assert_not_called()
+    hf_hub_download.assert_any_call(
+        repo_id="facebook/sam3.1",
+        filename="config.json",
+    )
+    hf_hub_download.assert_any_call(
+        repo_id="facebook/sam3.1",
+        filename="sam3.1_multiplex.pt",
+    )
+    assert (
+        builder.call_args.kwargs["checkpoint_path"]
+        == "/tmp/facebook-sam3.1/sam3.1_multiplex.pt"
+    )
     assert builder.call_args.kwargs["load_from_HF"] is False
 
 
@@ -197,13 +248,14 @@ def test_checkpoint_env_overrides_sam31_hf_download(monkeypatch, tmp_path, samge
 
 
 def test_sam31_missing_checkpoint_helper_has_clear_error(monkeypatch, tmp_path, samgeo3):
-    """Old sam3 packages should fail with an upgrade message for SAM 3.1."""
+    """SAM 3.1 reports a clear error when no downloader path is available."""
     bpe_path = tmp_path / "bpe.txt.gz"
     bpe_path.write_text("stub")
     builder, _ = _patch_meta_build(monkeypatch, samgeo3)
     monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", None)
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
 
-    with pytest.raises(ImportError, match="newer sam3 package"):
+    with pytest.raises(ImportError, match="facebook/sam3.1"):
         _init_meta_backend(
             samgeo3,
             bpe_path=str(bpe_path),

--- a/tests/test_samgeo3.py
+++ b/tests/test_samgeo3.py
@@ -1,0 +1,212 @@
+"""Fast constructor tests for SAM3 model selection logic."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+def _load_samgeo3(monkeypatch):
+    """Load samgeo3.py with minimal stubs for heavy optional dependencies."""
+    repo_root = Path(__file__).resolve().parents[1]
+    samgeo_dir = repo_root / "samgeo"
+
+    package = types.ModuleType("samgeo")
+    package.__path__ = [str(samgeo_dir)]
+
+    common = types.ModuleType("samgeo.common")
+    common.get_device = lambda: "cpu"
+    common.download_file = lambda url, output, quiet=True: output
+    common.show_image = lambda *args, **kwargs: None
+    package.common = common
+
+    registry_path = samgeo_dir / "model_registry.py"
+    registry_spec = importlib.util.spec_from_file_location(
+        "samgeo.model_registry", registry_path
+    )
+    registry = importlib.util.module_from_spec(registry_spec)
+    registry_spec.loader.exec_module(registry)
+
+    monkeypatch.setitem(sys.modules, "cv2", types.ModuleType("cv2"))
+    monkeypatch.setitem(sys.modules, "samgeo", package)
+    monkeypatch.setitem(sys.modules, "samgeo.common", common)
+    monkeypatch.setitem(sys.modules, "samgeo.model_registry", registry)
+
+    module_path = samgeo_dir / "samgeo3.py"
+    spec = importlib.util.spec_from_file_location("samgeo.samgeo3", module_path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "samgeo.samgeo3", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _DummyModel:
+    def to(self, device):
+        self.device = device
+        return self
+
+
+def _patch_meta_build(monkeypatch, samgeo3):
+    builder = Mock(return_value=_DummyModel())
+    processor = Mock()
+    monkeypatch.setattr(samgeo3, "build_sam3_image_model", builder, raising=False)
+    monkeypatch.setattr(samgeo3, "MetaSam3Processor", processor, raising=False)
+    return builder, processor
+
+
+def _init_meta_backend(samgeo3, **overrides):
+    params = {
+        "model_id": "facebook/sam3.1",
+        "bpe_path": None,
+        "device": "cpu",
+        "eval_mode": True,
+        "checkpoint_path": None,
+        "load_from_HF": True,
+        "enable_segmentation": True,
+        "enable_inst_interactivity": False,
+        "compile_mode": False,
+        "resolution": 1008,
+        "confidence_threshold": 0.5,
+    }
+    params.update(overrides)
+    model = samgeo3.SamGeo3.__new__(samgeo3.SamGeo3)
+    model._init_meta_backend(**params)
+
+
+@pytest.fixture
+def samgeo3(monkeypatch):
+    return _load_samgeo3(monkeypatch)
+
+
+def test_samgeo3_rejects_invalid_backend_before_dependency_checks(samgeo3):
+    """Backend typos should fail as user errors, even without SAM3 installed."""
+    with pytest.raises(ValueError, match="Invalid backend"):
+        samgeo3.SamGeo3(backend="unknown")
+
+
+def test_sam31_rejects_transformers_backend_before_dependency_checks(samgeo3):
+    """SAM 3.1 is a Meta checkpoint path, not a Transformers model id."""
+    with pytest.raises(ValueError, match="backend='meta'"):
+        samgeo3.SamGeo3(backend="transformers", model_id="facebook/sam3.1")
+
+
+def test_samgeo3_constructor_preserves_custom_meta_model_id(monkeypatch, samgeo3):
+    """Custom Meta model ids remain accepted for direct SamGeo3 users."""
+    monkeypatch.setattr(samgeo3, "SAM3_META_AVAILABLE", True)
+    init_meta = Mock()
+    monkeypatch.setattr(samgeo3.SamGeo3, "_init_meta_backend", init_meta)
+
+    model = samgeo3.SamGeo3(
+        backend="meta",
+        model_id="custom/sam3-checkpoint",
+        device="cpu",
+    )
+
+    assert model.model_id == "custom/sam3-checkpoint"
+    init_meta.assert_called_once()
+    assert init_meta.call_args.kwargs["model_id"] == "custom/sam3-checkpoint"
+
+
+def test_sam31_load_from_hf_uses_versioned_checkpoint_download(
+    monkeypatch, tmp_path, samgeo3
+):
+    """SAM 3.1 selects the sam3.1 checkpoint helper without touching the network."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+    checkpoint_path = tmp_path / "sam3.1_multiplex.pt"
+
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    downloader = Mock(return_value=str(checkpoint_path))
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", downloader)
+
+    _init_meta_backend(
+        samgeo3,
+        bpe_path=str(bpe_path),
+    )
+
+    downloader.assert_called_once_with(version="sam3.1")
+    assert builder.call_args.kwargs["checkpoint_path"] == str(checkpoint_path)
+    assert builder.call_args.kwargs["load_from_HF"] is False
+
+
+def test_sam31_explicit_checkpoint_skips_hf_download(monkeypatch, tmp_path, samgeo3):
+    """Explicit checkpoints remain authoritative and avoid HF downloads."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+    checkpoint_path = tmp_path / "local-sam31.pt"
+    checkpoint_path.write_text("stub")
+
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    downloader = Mock()
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", downloader)
+
+    _init_meta_backend(
+        samgeo3,
+        bpe_path=str(bpe_path),
+        checkpoint_path=str(checkpoint_path),
+    )
+
+    downloader.assert_not_called()
+    assert builder.call_args.kwargs["checkpoint_path"] == str(checkpoint_path)
+    assert builder.call_args.kwargs["load_from_HF"] is False
+
+
+def test_default_sam3_keeps_standard_hf_loading(monkeypatch, tmp_path, samgeo3):
+    """The existing SAM3 default path should not call the SAM 3.1 downloader."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    downloader = Mock()
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", downloader)
+
+    _init_meta_backend(
+        samgeo3,
+        model_id="facebook/sam3",
+        bpe_path=str(bpe_path),
+    )
+
+    downloader.assert_not_called()
+    assert builder.call_args.kwargs["checkpoint_path"] is None
+    assert builder.call_args.kwargs["load_from_HF"] is True
+
+
+def test_checkpoint_env_overrides_sam31_hf_download(monkeypatch, tmp_path, samgeo3):
+    """SAM3_CHECKPOINT_PATH keeps deployment overrides backward compatible."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+    env_checkpoint = tmp_path / "env-sam31.pt"
+    env_checkpoint.write_text("stub")
+    monkeypatch.setenv("SAM3_CHECKPOINT_PATH", str(env_checkpoint))
+
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    downloader = Mock()
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", downloader)
+
+    _init_meta_backend(
+        samgeo3,
+        bpe_path=str(bpe_path),
+    )
+
+    downloader.assert_not_called()
+    assert builder.call_args.kwargs["checkpoint_path"] == str(env_checkpoint)
+    assert builder.call_args.kwargs["load_from_HF"] is False
+
+
+def test_sam31_missing_checkpoint_helper_has_clear_error(monkeypatch, tmp_path, samgeo3):
+    """Old sam3 packages should fail with an upgrade message for SAM 3.1."""
+    bpe_path = tmp_path / "bpe.txt.gz"
+    bpe_path.write_text("stub")
+    builder, _ = _patch_meta_build(monkeypatch, samgeo3)
+    monkeypatch.setattr(samgeo3, "download_ckpt_from_hf", None)
+
+    with pytest.raises(ImportError, match="newer sam3 package"):
+        _init_meta_backend(
+            samgeo3,
+            bpe_path=str(bpe_path),
+        )
+
+    builder.assert_not_called()


### PR DESCRIPTION
Hi, this adds SAM 3.1 as a backward-compatible SAM3 model option, following the scope discussed in #520.

What changed:
- added `facebook/sam3.1` to the SAM3 model registry while keeping `facebook/sam3` as the default
- moved API model ids/defaults/extras into a small shared `samgeo/model_registry.py` so the model list has one source of truth
- updated `get_model()` to pass the requested SAM3 `model_id` into `SamGeo3`
- updated `SamGeo3` so `model_id='facebook/sam3.1'` uses the SAM 3.1 Hugging Face checkpoint via the Meta backend
- kept the Transformers backend limited to `facebook/sam3`, since the SAM 3.1 HF repo is a checkpoint repo rather than a Transformers model repo
- bumped the `samgeo3` optional dependency to `sam3>=0.1.4`, which is needed for the SAM 3.1 checkpoint helper
- updated API/install docs and added lightweight registry/API coverage

I intentionally did not add the new SAM 3.1 video multiplex predictor here. That looks like a separate follow-up because it uses different upstream builder APIs and would be a larger behavior change.

Tested locally:
- `python -m pytest tests/test_model_registry.py -q`
- `python -m py_compile samgeo/model_registry.py samgeo/api.py samgeo/samgeo3.py tests/test_api.py tests/test_model_registry.py`
- `git diff --cached --check`

Note: `python -m pytest tests/test_api.py -q` skips in my local environment because FastAPI is not installed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the SAM 3.1 model identifier `facebook/sam3.1`, including updated `/models` output.

* **Bug Fixes**
  * Improved validation for `model_id`/backend combinations and clearer guidance when using Transformers vs Meta backends.
  * Invalid model configuration now returns HTTP 400 with the original error message; SAM 3 and SAM 3.1 are cached independently.

* **Documentation**
  * Expanded installation steps and API request documentation with concrete SAM 3.1 `model_id` examples.

* **Dependencies**
  * Updated `samgeo3` extra to require `sam3>=0.1.4`.

* **Tests**
  * Added regression and model-registry coverage for SAM 3.1 handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->