### PR TITLE
Fix SamGeo3Video AssertionError on re-instantiation

### DIFF
--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -4,7 +4,10 @@ https://github.com/facebookresearch/sam3
 
 import glob
 import inspect
+import logging
 import os
+import warnings
+import weakref
 from contextlib import nullcontext
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -63,6 +66,8 @@ try:
 except ImportError:
     pass
 
+
+logger = logging.getLogger(__name__)
 
 SAM31_CKPT_NAME = "sam3.1_multiplex.pt"
 SAM31_CONFIG_NAME = "config.json"
@@ -4088,9 +4093,12 @@ class SamGeo3Video:
         >>> sam.close()
     """
 
-    # Tracks the most recently created predictor so a new instance can tear
-    # down a previous one before initializing (see _cleanup_previous_predictor).
-    _active_predictor: Optional["SamGeo3Video"] = None
+    # Weak reference to the most recently created instance so a new instance
+    # can tear down a previous one before initializing (see
+    # _cleanup_previous_predictor). A weakref is used so this class-level
+    # tracking does not itself keep the instance (and its worker processes /
+    # GPU memory) alive after the user drops their own reference.
+    _active_predictor: Optional["weakref.ReferenceType[SamGeo3Video]"] = None
 
     def __init__(
         self,
@@ -4148,7 +4156,7 @@ class SamGeo3Video:
         self.predictor = build_sam3_video_predictor(
             gpus_to_use=gpus_to_use, bpe_path=bpe_path, **kwargs
         )
-        SamGeo3Video._active_predictor = self
+        SamGeo3Video._active_predictor = weakref.ref(self)
         self.gpus_to_use = gpus_to_use
         self.session_id = None
         self.video_path = None
@@ -4175,26 +4183,50 @@ class SamGeo3Video:
 
         This method shuts down the previously tracked predictor (which notifies
         its workers and destroys its process group) and, as a fallback, destroys
-        any process group that is still initialized.
+        any process group that is still initialized. If a process group is found
+        but no previous ``SamGeo3Video`` was tracked, the group may belong to
+        other code in the process, so a warning is emitted before it is
+        destroyed (the SAM3 predictor cannot start while a group is
+        initialized).
         """
         import torch
 
-        previous = SamGeo3Video._active_predictor
+        ref = SamGeo3Video._active_predictor
+        previous = ref() if ref is not None else None
         if previous is not None:
             try:
                 previous.shutdown()
             except Exception:
-                pass
+                # Don't let a partial teardown block creating the new predictor,
+                # but surface it so cleanup problems can be diagnosed.
+                logger.warning(
+                    "Failed to shut down the previous SamGeo3Video cleanly; "
+                    "falling back to destroying the process group.",
+                    exc_info=True,
+                )
             finally:
                 SamGeo3Video._active_predictor = None
 
-        # Fallback: a process group may still be initialized (e.g. it was set up
-        # outside of SamGeo3Video, or the previous shutdown failed part-way).
+        # Fallback: a process group may still be initialized (the previous
+        # shutdown failed part-way, the previous instance was garbage-collected
+        # without shutdown(), or it was set up outside of SamGeo3Video).
         if torch.distributed.is_available() and torch.distributed.is_initialized():
+            if previous is None:
+                warnings.warn(
+                    "An existing torch.distributed process group was found and "
+                    "will be destroyed so the SAM3 video predictor can "
+                    "initialize. If this group belongs to other code, create "
+                    "the SamGeo3Video instance before initializing that group.",
+                    stacklevel=2,
+                )
             try:
                 torch.distributed.destroy_process_group()
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to destroy the existing torch.distributed process "
+                    "group.",
+                    exc_info=True,
+                )
 
     def set_video(
         self,
@@ -5442,7 +5474,8 @@ class SamGeo3Video:
         """
         self.close()
         self.predictor.shutdown()
-        if SamGeo3Video._active_predictor is self:
+        ref = SamGeo3Video._active_predictor
+        if ref is not None and ref() is self:
             SamGeo3Video._active_predictor = None
         print("Predictor shutdown complete.")
 

--- a/samgeo/samgeo3.py
+++ b/samgeo/samgeo3.py
@@ -4088,6 +4088,10 @@ class SamGeo3Video:
         >>> sam.close()
     """
 
+    # Tracks the most recently created predictor so a new instance can tear
+    # down a previous one before initializing (see _cleanup_previous_predictor).
+    _active_predictor: Optional["SamGeo3Video"] = None
+
     def __init__(
         self,
         gpus_to_use: Optional[List[int]] = None,
@@ -4134,9 +4138,17 @@ class SamGeo3Video:
 
         print(f"Using GPUs: {gpus_to_use}")
 
+        # The SAM3 multi-GPU predictor asserts that no torch.distributed process
+        # group is already initialized. A previous SamGeo3Video created in the
+        # same session (e.g. re-running a notebook cell) leaves its group and
+        # worker processes alive, which would trip that assertion. Tear down any
+        # previous predictor and stale process group before building a new one.
+        self._cleanup_previous_predictor()
+
         self.predictor = build_sam3_video_predictor(
             gpus_to_use=gpus_to_use, bpe_path=bpe_path, **kwargs
         )
+        SamGeo3Video._active_predictor = self
         self.gpus_to_use = gpus_to_use
         self.session_id = None
         self.video_path = None
@@ -4147,6 +4159,42 @@ class SamGeo3Video:
         self._tif_source = None
         self._tif_dir = None
         self._tif_names = None
+
+    @staticmethod
+    def _cleanup_previous_predictor() -> None:
+        """Tear down a previously created predictor and any stale process group.
+
+        The SAM3 multi-GPU video predictor initializes a ``torch.distributed``
+        process group and spawns worker processes, and it asserts that no
+        process group is already initialized when it starts. Because
+        ``__del__`` only closes the active session (not the predictor), a
+        previous ``SamGeo3Video`` instance created in the same Python process
+        keeps its process group and workers alive, causing an ``AssertionError``
+        when a new instance is created (for example, when a notebook cell is
+        re-run).
+
+        This method shuts down the previously tracked predictor (which notifies
+        its workers and destroys its process group) and, as a fallback, destroys
+        any process group that is still initialized.
+        """
+        import torch
+
+        previous = SamGeo3Video._active_predictor
+        if previous is not None:
+            try:
+                previous.shutdown()
+            except Exception:
+                pass
+            finally:
+                SamGeo3Video._active_predictor = None
+
+        # Fallback: a process group may still be initialized (e.g. it was set up
+        # outside of SamGeo3Video, or the previous shutdown failed part-way).
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            try:
+                torch.distributed.destroy_process_group()
+            except Exception:
+                pass
 
     def set_video(
         self,
@@ -5394,6 +5442,8 @@ class SamGeo3Video:
         """
         self.close()
         self.predictor.shutdown()
+        if SamGeo3Video._active_predictor is self:
+            SamGeo3Video._active_predictor = None
         print("Predictor shutdown complete.")
 
     def __del__(self):


### PR DESCRIPTION
## Problem

Creating a `SamGeo3Video` a second time in the same process (for example, re-running a notebook cell) raises an `AssertionError` from the SAM3 multi-GPU predictor:

```python
sam = SamGeo3Video()
sam.set_video(video_path)
sam.init_tracker()
...
```

```
File .../sam3/model/sam3_video_predictor.py:229, in _start_nccl_process_group
--> 229     assert not torch.distributed.is_initialized()
AssertionError:
```

## Root cause

On a multi-GPU machine, `SamGeo3Video()` defaults to all GPUs, so the SAM3 predictor runs in multi-GPU mode: it spawns worker processes and initializes a `torch.distributed` (NCCL) process group. Before doing so it asserts that no process group is already initialized (`sam3_video_predictor.py:229`).

`SamGeo3Video.__del__` only calls `close()` (which closes the current *session*), **not** `shutdown()` (which tears down the workers and destroys the process group). So a previously created instance keeps its process group alive. When a new instance is created, `torch.distributed.is_initialized()` is already `True` and the assertion fails.

## Fix

- Track the most recently created predictor in a class-level `_active_predictor` reference.
- In `__init__`, before building the new predictor, call `_cleanup_previous_predictor()` which:
  - shuts down the previously tracked predictor (notifying its workers and destroying its process group), and
  - as a fallback, destroys any process group that is still initialized.
- `shutdown()` now clears the class-level reference when it applies to the current instance.

This makes re-instantiation within a single session work as expected, and avoids leaking worker processes / GPU memory from the previous instance.

## Testing

Verified on a 2-GPU machine by instantiating `SamGeo3Video()` twice in the same process:

- First instantiation succeeds (`torch.distributed.is_initialized()` → `True`).
- Second instantiation (which previously raised `AssertionError`) now cleanly shuts down the stale predictor (`Predictor shutdown complete.`) and builds successfully.
- `_active_predictor` correctly tracks the live instance and resets to `None` after `shutdown()`.

pre-commit passes on the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when starting multiple video prediction sessions in the same Python session.
  * Prevented initialization errors caused by stale multi-GPU/distributed state from earlier sessions.
  * Added more reliable cleanup to ensure new sessions run correctly after shutdown, including graceful handling of leftover processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->