### PR TITLE
Add wildfire burn area detection example notebook

### DIFF
--- a/docs/examples/wildfire_burn_area.ipynb
+++ b/docs/examples/wildfire_burn_area.ipynb
@@ -51,7 +51,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "import leafmap\n",
     "from samgeo import SamGeo, tms_to_geotiff"
    ]

--- a/docs/examples/wildfire_burn_area.ipynb
+++ b/docs/examples/wildfire_burn_area.ipynb
@@ -204,14 +204,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "sam.show_anns(\n",
-    "    figsize=(14, 10),\n",
-    "    axis=\"off\",\n",
-    "    alpha=0.4,\n",
-    "    output=\"campfire_annotated.png\",\n",
-    ")"
-   ]
+   "source": "m.add_raster(mask_path, layer_name=\"Generated Masks\", opacity=0.5, cmap=\"viridis\")\nm"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/wildfire_burn_area.ipynb
+++ b/docs/examples/wildfire_burn_area.ipynb
@@ -1,0 +1,315 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Wildfire Burn Area Detection with the Segment Anything Model\n",
+    "\n",
+    "[![image](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/opengeos/segment-geospatial/blob/main/docs/examples/wildfire_burn_area.ipynb)\n",
+    "\n",
+    "This notebook demonstrates how to use the [Segment Anything Model (SAM)](https://github.com/facebookresearch/segment-anything) to detect and delineate wildfire burn areas from satellite imagery. The workflow supports post-fire damage assessment and environmental monitoring pipelines.\n",
+    "\n",
+    "**Study Area:** 2018 Camp Fire — Paradise, California, USA. One of the most destructive wildfires in California history, burning over 153,000 acres.\n",
+    "\n",
+    "**Outline:**\n",
+    "- Install dependencies\n",
+    "- Download post-fire satellite imagery\n",
+    "- Run automatic mask generation with SamGeo\n",
+    "- Export burn area polygons to GeoJSON / Shapefile\n",
+    "- Visualize results on an interactive map"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install dependencies\n",
+    "\n",
+    "Uncomment the line below if running in Google Colab or a fresh environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install segment-geospatial leafmap"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import leafmap\n",
+    "from samgeo import SamGeo, tms_to_geotiff"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create an interactive map\n",
+    "\n",
+    "Centre the map over the Camp Fire burn scar in Paradise, CA. You can pan and zoom to adjust the region of interest before downloading imagery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m = leafmap.Map(center=[39.758, -121.574], zoom=13)\n",
+    "m.add_basemap(\"SATELLITE\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define area of interest\n",
+    "\n",
+    "The bounding box below covers the core burn perimeter of the 2018 Camp Fire near Paradise, CA. Adjust if you drew a custom rectangle on the map above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# [west, south, east, north] in WGS84 decimal degrees\n",
+    "bbox = [-121.64, 39.73, -121.50, 39.82]\n",
+    "\n",
+    "# If you drew a rectangle on the map, replace bbox with:\n",
+    "# bbox = m.user_roi_bounds()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download satellite imagery\n",
+    "\n",
+    "Convert map tiles to a GeoTIFF using the SATELLITE basemap. Zoom level 14 gives roughly 10 m/pixel resolution — sufficient to distinguish burn scars from surrounding vegetation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_path = \"campfire_postfire.tif\"\n",
+    "\n",
+    "tms_to_geotiff(\n",
+    "    output=image_path,\n",
+    "    bbox=bbox,\n",
+    "    zoom=14,\n",
+    "    source=\"Satellite\",\n",
+    "    overwrite=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Verify the downloaded image on the map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "m.add_raster(image_path, layer_name=\"Post-fire imagery\")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Initialize SamGeo\n",
+    "\n",
+    "Load the ViT-H checkpoint. The model will be downloaded automatically on first run (~2.4 GB). A CUDA-enabled GPU is recommended but not required."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sam = SamGeo(\n",
+    "    model_type=\"vit_h\",\n",
+    "    automatic=True,\n",
+    "    sam_kwargs=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate segmentation masks\n",
+    "\n",
+    "Run automatic mask generation on the post-fire image. `batch=True` tiles the image into 512 × 512 px chips, which helps with large rasters and reduces GPU memory pressure."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask_path = \"campfire_masks.tif\"\n",
+    "\n",
+    "sam.generate(\n",
+    "    source=image_path,\n",
+    "    output=mask_path,\n",
+    "    foreground=True,\n",
+    "    batch=True,\n",
+    "    batch_sample_size=(512, 512),\n",
+    "    erosion_kernel=(3, 3),\n",
+    "    mask_multiplier=255,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualise masks\n",
+    "\n",
+    "Display the generated masks overlaid on the source imagery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sam.show_anns(\n",
+    "    figsize=(14, 10),\n",
+    "    axis=\"off\",\n",
+    "    alpha=0.4,\n",
+    "    output=\"campfire_annotated.png\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert masks to vector polygons\n",
+    "\n",
+    "Export the raster masks as GeoJSON and Shapefile for use in GIS workflows (QGIS, ArcGIS, GeoPandas, etc.)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geojson_path = \"campfire_burn_areas.geojson\"\n",
+    "shapefile_path = \"campfire_burn_areas.shp\"\n",
+    "\n",
+    "sam.tiff_to_geojson(\n",
+    "    tiff_path=mask_path,\n",
+    "    output=geojson_path,\n",
+    "    simplify_tolerance=None,\n",
+    ")\n",
+    "\n",
+    "sam.tiff_to_shp(\n",
+    "    tiff_path=mask_path,\n",
+    "    output=shapefile_path,\n",
+    "    simplify_tolerance=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display results on an interactive map\n",
+    "\n",
+    "Overlay the burn area polygons on the satellite basemap. Orange outlines highlight detected segments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "style = {\n",
+    "    \"color\": \"#FF6B35\",\n",
+    "    \"weight\": 2,\n",
+    "    \"fillColor\": \"#FF6B35\",\n",
+    "    \"fillOpacity\": 0.3,\n",
+    "}\n",
+    "\n",
+    "m.add_vector(\n",
+    "    geojson_path,\n",
+    "    layer_name=\"Burn Area Polygons\",\n",
+    "    style=style,\n",
+    ")\n",
+    "m"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This notebook showed how to:\n",
+    "\n",
+    "1. Download post-fire satellite imagery for a defined bounding box\n",
+    "2. Apply `SamGeo` automatic mask generation to segment burn areas\n",
+    "3. Export detected polygons as GeoJSON and Shapefile\n",
+    "4. Visualise results interactively with `leafmap`\n",
+    "\n",
+    "The same pipeline can be applied to any wildfire event by changing `bbox` to match the target fire perimeter. For finer-grained burn severity analysis, consider combining this segmentation output with Sentinel-2 dNBR (differenced Normalized Burn Ratio) rasters.\n",
+    "\n",
+    "## References\n",
+    "\n",
+    "- [Segment Anything Model (SAM)](https://github.com/facebookresearch/segment-anything) — Kirillov et al., 2023\n",
+    "- [samgeo](https://samgeo.gishub.org/) — Wu et al., 2023\n",
+    "- [leafmap](https://leafmap.org/)\n",
+    "- [2018 Camp Fire — CAL FIRE](https://www.fire.ca.gov/incidents/2018/11/8/camp-fire/)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Adds a new example notebook: `docs/examples/wildfire_burn_area.ipynb`

Demonstrates how to use SamGeo for wildfire burn area detection from post-fire satellite imagery, using the 2018 Camp Fire (Paradise, CA) as a study area.

## What this notebook covers

- Downloading post-fire satellite imagery via `tms_to_geotiff()`
- Running `SamGeo` automatic mask generation with batch tiling (512×512 px chips)
- Exporting detected burn polygons as GeoJSON and Shapefile
- Interactive visualization with `leafmap`

## Motivation

No wildfire-specific example currently exists in the docs. Wildfire burn area mapping is a common remote sensing use case in environmental monitoring, disaster response, and post-fire ecological assessment workflows. This notebook gives users a ready-to-run starting point for that domain.

## Related

Follows the structure of the existing `satellite.ipynb` example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new step-by-step Jupyter notebook demonstrating wildfire burn-area mapping from satellite imagery.
  * Covers imagery download, automated segmentation, and mask visualization on an interactive map.
  * Converts results into GeoJSON and Shapefile polygon outputs with styled overlays.
  * Includes a full workflow summary and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->