### PR TITLE
fix: format wildfire example notebook

### DIFF
--- a/docs/examples/wildfire_burn_area.ipynb
+++ b/docs/examples/wildfire_burn_area.ipynb
@@ -52,6 +52,7 @@
    "outputs": [],
    "source": [
     "import leafmap\n",
+    "\n",
     "from samgeo import SamGeo, tms_to_geotiff"
    ]
   },
@@ -204,7 +205,10 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "m.add_raster(mask_path, layer_name=\"Generated Masks\", opacity=0.5, cmap=\"viridis\")\nm"
+   "source": [
+    "m.add_raster(mask_path, layer_name=\"Generated Masks\", opacity=0.5, cmap=\"viridis\")\n",
+    "m"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- apply Ruff's required formatting to the wildfire burn area notebook
- restore a passing pre-commit check on `main`

## Test plan
- [x] Run `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reformatted code examples in the wildfire burn area notebook for improved readability.
  * Notebook behavior and results remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->